### PR TITLE
Fix editor hangs and sync colors with Omarchy themes

### DIFF
--- a/src/Main.qml
+++ b/src/Main.qml
@@ -285,6 +285,7 @@ ApplicationWindow {
         darkMode: win.darkMode
         textColor: win.textColor
         strongTextColor: win.strongTextColor
+        activeButtonColor: backend.themeAccent
         containerWidth: win.width
         containerHeight: win.height
 

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -16,11 +16,11 @@ ApplicationWindow {
     title: (backend.modified ? "* " : "") + backend.fileName + " - Omawrite"
 
     readonly property bool darkMode: backend.darkMode
-    readonly property color pageColor: darkMode ? "#101010" : "#ffffff"
-    readonly property color textColor: darkMode ? "#d0d0d0" : "#42464c"
-    readonly property color strongTextColor: darkMode ? "#eeeeee" : "#222324"
+    readonly property color pageColor: backend.themeBackground
+    readonly property color textColor: backend.themeForeground
+    readonly property color strongTextColor: backend.themeForeground
     readonly property color mutedColor: darkMode ? "#909191" : "#aeb1b5"
-    readonly property color selectionFill: darkMode ? "#186a9a" : "#2077b2"
+    readonly property color selectionFill: backend.themeSelection
     readonly property int editorFontPixelSize: 20
     readonly property int editorWidth: Math.min(
         Math.round(writerFontMetrics.averageCharacterWidth * 65),
@@ -36,7 +36,7 @@ ApplicationWindow {
     property bool awaitingPendingSave: false
 
     Material.theme: darkMode ? Material.Dark : Material.Light
-    Material.accent: darkMode ? "#5584aa" : "#2077b2"
+    Material.accent: backend.themeAccent
     color: pageColor
 
     onClosing: function(close) {

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -572,7 +572,8 @@ void Backend::loadOmarchyTheme() {
     m_themeSelection = m_darkMode ? QStringLiteral("#186a9a") : QStringLiteral("#2077b2");
 
     const QString colorsPath = QDir::homePath()
-        + QStringLiteral("/.config/omarchy/current/theme/colors.toml");
+        + QStringLiteral("/.local/state/omarchy/current/theme/colors.toml");
+    QString themeMode;
     QFile file(colorsPath);
     if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         QTextStream in(&file);
@@ -592,29 +593,39 @@ void Backend::loadOmarchyTheme() {
                         || (value.front() == QLatin1Char('\'') && value.back() == QLatin1Char('\''))))
                 value = value.mid(1, value.size() - 2);
 
-            if (key == QStringLiteral("background"))
+            if (key == QStringLiteral("mode"))
+                themeMode = value;
+            else if (key == QStringLiteral("background"))
                 m_themeBackground = value;
             else if (key == QStringLiteral("foreground"))
                 m_themeForeground = value;
             else if (key == QStringLiteral("accent"))
                 m_themeAccent = value;
-            else if (key == QStringLiteral("selection_background"))
+            else if (key == QStringLiteral("selection"))
                 m_themeSelection = value;
         }
     }
 
-    // Omarchy themes don't declare whether they're dark or light, so derive it
-    // from the resolved background color and let it override the OS-reported
-    // dark/light mode when they disagree.
-    const QColor background(m_themeBackground);
-    if (background.isValid()) {
-        const double luminance = 0.299 * background.redF() + 0.587 * background.greenF()
-            + 0.114 * background.blueF();
-        const bool themeIsDark = luminance < 0.5;
-        if (themeIsDark != m_darkMode) {
-            m_darkMode = themeIsDark;
-            emit darkModeChanged();
+    bool themeModeKnown = false;
+    bool themeIsDark = m_darkMode;
+    if (themeMode == QStringLiteral("dark")) {
+        themeIsDark = true;
+        themeModeKnown = true;
+    } else if (themeMode == QStringLiteral("light")) {
+        themeIsDark = false;
+        themeModeKnown = true;
+    } else {
+        const QColor background(m_themeBackground);
+        if (background.isValid()) {
+            const double luminance = 0.299 * background.redF()
+                + 0.587 * background.greenF() + 0.114 * background.blueF();
+            themeIsDark = luminance < 0.5;
+            themeModeKnown = true;
         }
+    }
+    if (themeModeKnown && themeIsDark != m_darkMode) {
+        m_darkMode = themeIsDark;
+        emit darkModeChanged();
     }
 
     if (m_highlighter) {
@@ -630,7 +641,8 @@ void Backend::watchOmarchyTheme() {
     if (!watched.isEmpty())
         m_themeWatcher.removePaths(watched);
 
-    const QString currentDir = QDir::homePath() + QStringLiteral("/.config/omarchy/current");
+    const QString currentDir = QDir::homePath()
+        + QStringLiteral("/.local/state/omarchy/current");
     const QString themeDir = currentDir + QStringLiteral("/theme");
     const QString colorsPath = themeDir + QStringLiteral("/colors.toml");
 

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -1,6 +1,7 @@
 #include "backend.h"
 
 #include <QClipboard>
+#include <QColor>
 #include <QCoreApplication>
 #include <QDir>
 #include <QFile>
@@ -23,6 +24,7 @@
 #include <QTextBlockFormat>
 #include <QTextCursor>
 #include <QTextDocument>
+#include <QTextStream>
 #include <QUrl>
 #include <QVariantMap>
 #include <QWindow>
@@ -114,6 +116,17 @@ Backend::Backend(QObject *parent) : QObject(parent) {
 
                 emit externalChangeDetected(deleted, m_modified);
             });
+
+    loadOmarchyTheme();
+    watchOmarchyTheme();
+    connect(&m_themeWatcher, &QFileSystemWatcher::fileChanged, this, [this]() {
+        loadOmarchyTheme();
+        watchOmarchyTheme();
+    });
+    connect(&m_themeWatcher, &QFileSystemWatcher::directoryChanged, this, [this]() {
+        loadOmarchyTheme();
+        watchOmarchyTheme();
+    });
 }
 
 Backend::~Backend() = default;
@@ -141,8 +154,7 @@ void Backend::setDarkMode(bool darkMode) {
         return;
 
     m_darkMode = darkMode;
-    if (m_highlighter)
-        m_highlighter->setDarkMode(m_darkMode);
+    loadOmarchyTheme();
     emit darkModeChanged();
 }
 
@@ -160,6 +172,7 @@ void Backend::attachDocument(QObject *textDocument) {
     m_lastDocumentText = m_document->toPlainText();
     m_highlighter = new MarkdownHighlighter(m_document);
     m_highlighter->setDarkMode(m_darkMode);
+    m_highlighter->setColors(m_themeBackground, m_themeForeground, m_themeAccent);
 
     connect(m_document, &QTextDocument::contentsChange, this,
             [this](int position, int, int charsAdded) {
@@ -550,6 +563,83 @@ void Backend::watchCurrentFile() {
         m_fileWatcher.removePaths(watched);
     if (m_fileUrl.isLocalFile() && QFileInfo::exists(m_fileUrl.toLocalFile()))
         m_fileWatcher.addPath(m_fileUrl.toLocalFile());
+}
+
+void Backend::loadOmarchyTheme() {
+    m_themeBackground = m_darkMode ? QStringLiteral("#101010") : QStringLiteral("#ffffff");
+    m_themeForeground = m_darkMode ? QStringLiteral("#eeeeee") : QStringLiteral("#222324");
+    m_themeAccent = m_darkMode ? QStringLiteral("#5584aa") : QStringLiteral("#2077b2");
+    m_themeSelection = m_darkMode ? QStringLiteral("#186a9a") : QStringLiteral("#2077b2");
+
+    const QString colorsPath = QDir::homePath()
+        + QStringLiteral("/.config/omarchy/current/theme/colors.toml");
+    QFile file(colorsPath);
+    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QTextStream in(&file);
+        while (!in.atEnd()) {
+            const QString line = in.readLine().trimmed();
+            if (line.isEmpty() || line.startsWith(QLatin1Char('#')))
+                continue;
+
+            const int equals = line.indexOf(QLatin1Char('='));
+            if (equals < 0)
+                continue;
+
+            const QString key = line.left(equals).trimmed();
+            QString value = line.mid(equals + 1).trimmed();
+            if (value.size() >= 2
+                    && ((value.front() == QLatin1Char('"') && value.back() == QLatin1Char('"'))
+                        || (value.front() == QLatin1Char('\'') && value.back() == QLatin1Char('\''))))
+                value = value.mid(1, value.size() - 2);
+
+            if (key == QStringLiteral("background"))
+                m_themeBackground = value;
+            else if (key == QStringLiteral("foreground"))
+                m_themeForeground = value;
+            else if (key == QStringLiteral("accent"))
+                m_themeAccent = value;
+            else if (key == QStringLiteral("selection_background"))
+                m_themeSelection = value;
+        }
+    }
+
+    // Omarchy themes don't declare whether they're dark or light, so derive it
+    // from the resolved background color and let it override the OS-reported
+    // dark/light mode when they disagree.
+    const QColor background(m_themeBackground);
+    if (background.isValid()) {
+        const double luminance = 0.299 * background.redF() + 0.587 * background.greenF()
+            + 0.114 * background.blueF();
+        const bool themeIsDark = luminance < 0.5;
+        if (themeIsDark != m_darkMode) {
+            m_darkMode = themeIsDark;
+            emit darkModeChanged();
+        }
+    }
+
+    if (m_highlighter) {
+        m_highlighter->setDarkMode(m_darkMode);
+        m_highlighter->setColors(m_themeBackground, m_themeForeground, m_themeAccent);
+    }
+
+    emit themeColorsChanged();
+}
+
+void Backend::watchOmarchyTheme() {
+    const QStringList watched = m_themeWatcher.files() + m_themeWatcher.directories();
+    if (!watched.isEmpty())
+        m_themeWatcher.removePaths(watched);
+
+    const QString currentDir = QDir::homePath() + QStringLiteral("/.config/omarchy/current");
+    const QString themeDir = currentDir + QStringLiteral("/theme");
+    const QString colorsPath = themeDir + QStringLiteral("/colors.toml");
+
+    if (QDir(currentDir).exists())
+        m_themeWatcher.addPath(currentDir);
+    if (QDir(themeDir).exists())
+        m_themeWatcher.addPath(themeDir);
+    if (QFile::exists(colorsPath))
+        m_themeWatcher.addPath(colorsPath);
 }
 
 QUrl Backend::suggestedSaveUrl() const {

--- a/src/backend.h
+++ b/src/backend.h
@@ -23,6 +23,10 @@ class Backend : public QObject {
     Q_PROPERTY(QString status READ status NOTIFY statusChanged)
     Q_PROPERTY(int wordCount READ wordCount NOTIFY wordCountChanged)
     Q_PROPERTY(bool darkMode READ darkMode WRITE setDarkMode NOTIFY darkModeChanged)
+    Q_PROPERTY(QString themeBackground READ themeBackground NOTIFY themeColorsChanged)
+    Q_PROPERTY(QString themeForeground READ themeForeground NOTIFY themeColorsChanged)
+    Q_PROPERTY(QString themeAccent READ themeAccent NOTIFY themeColorsChanged)
+    Q_PROPERTY(QString themeSelection READ themeSelection NOTIFY themeColorsChanged)
 
 public:
     explicit Backend(QObject *parent = nullptr);
@@ -38,6 +42,10 @@ public:
     int wordCount() const { return m_wordCount; }
     bool darkMode() const { return m_darkMode; }
     void setDarkMode(bool darkMode);
+    QString themeBackground() const { return m_themeBackground; }
+    QString themeForeground() const { return m_themeForeground; }
+    QString themeAccent() const { return m_themeAccent; }
+    QString themeSelection() const { return m_themeSelection; }
     static int countWords(const QString &text);
     static QString normalizedLinkUrl(const QString &clipboardText);
     static QString suggestedFileName(const QString &text);
@@ -70,6 +78,7 @@ signals:
     void statusChanged();
     void wordCountChanged();
     void darkModeChanged();
+    void themeColorsChanged();
     void closeAfterSave();
     void openDialogRequested();
     void saveDialogRequested(const QUrl &suggestedUrl);
@@ -95,6 +104,8 @@ private:
     void clearRecovery();
     QString recoveryPath() const;
     void watchCurrentFile();
+    void loadOmarchyTheme();
+    void watchOmarchyTheme();
 
     QUrl m_fileUrl;
     bool m_modified = false;
@@ -118,4 +129,10 @@ private:
     bool m_hasKnownFileContents = false;
     QString m_recoveryPath;
     std::unique_ptr<QLockFile> m_recoveryLock;
+
+    QString m_themeBackground;
+    QString m_themeForeground;
+    QString m_themeAccent;
+    QString m_themeSelection;
+    QFileSystemWatcher m_themeWatcher;
 };

--- a/src/markdownhighlighter.cpp
+++ b/src/markdownhighlighter.cpp
@@ -19,6 +19,19 @@ void MarkdownHighlighter::setDarkMode(bool darkMode) {
     rehighlight();
 }
 
+void MarkdownHighlighter::setColors(const QString &background, const QString &foreground,
+                                    const QString &accent) {
+    if (m_customBackground == background && m_customForeground == foreground
+            && m_customAccent == accent)
+        return;
+
+    m_customBackground = background;
+    m_customForeground = foreground;
+    m_customAccent = accent;
+    rebuildFormats();
+    rehighlight();
+}
+
 void MarkdownHighlighter::setSearch(const QString &query, int currentMatchStart) {
     if (m_searchQuery == query && m_currentMatchStart == currentMatchStart)
         return;
@@ -30,12 +43,12 @@ void MarkdownHighlighter::setSearch(const QString &query, int currentMatchStart)
 void MarkdownHighlighter::rebuildFormats() {
     const QColor marker = m_darkMode ? QColor(QStringLiteral("#4f525a"))
                                      : QColor(QStringLiteral("#aeb1b5"));
-    const QColor background = m_darkMode ? QColor(QStringLiteral("#101010"))
-                                         : QColor(QStringLiteral("#ffffff"));
-    const QColor text = m_darkMode ? QColor(QStringLiteral("#eeeeee"))
-                                   : QColor(QStringLiteral("#222324"));
-    const QColor link = m_darkMode ? QColor(QStringLiteral("#5584aa"))
-                                   : QColor(QStringLiteral("#2077b2"));
+    const QColor background = !m_customBackground.isEmpty() ? QColor(m_customBackground)
+        : (m_darkMode ? QColor(QStringLiteral("#101010")) : QColor(QStringLiteral("#ffffff")));
+    const QColor text = !m_customForeground.isEmpty() ? QColor(m_customForeground)
+        : (m_darkMode ? QColor(QStringLiteral("#eeeeee")) : QColor(QStringLiteral("#222324")));
+    const QColor link = !m_customAccent.isEmpty() ? QColor(m_customAccent)
+        : (m_darkMode ? QColor(QStringLiteral("#5584aa")) : QColor(QStringLiteral("#2077b2")));
     const QColor quote = marker;
     const QColor codeBackground = m_darkMode ? QColor(QStringLiteral("#1c1a1a"))
                                              : QColor(QStringLiteral("#f8f8f8"));

--- a/src/markdownhighlighter.cpp
+++ b/src/markdownhighlighter.cpp
@@ -2,6 +2,7 @@
 
 #include <QColor>
 #include <QFont>
+#include <QFontMetricsF>
 #include <QTextDocument>
 
 MarkdownHighlighter::MarkdownHighlighter(QTextDocument *document)
@@ -42,10 +43,20 @@ void MarkdownHighlighter::rebuildFormats() {
     m_markerFormat = QTextCharFormat();
     m_markerFormat.setForeground(marker);
 
+    // A sub-pixel font size combined with a stretch factor used to make these
+    // markers occupy (close to) zero space, but that combination deadlocks Qt's
+    // font metrics engine on some platforms. Instead, use a normal font size and
+    // cancel out its advance width with negative absolute letter-spacing.
     m_hiddenMarkerFormat = QTextCharFormat();
     m_hiddenMarkerFormat.setForeground(background);
-    m_hiddenMarkerFormat.setFontPointSize(0.1);
-    m_hiddenMarkerFormat.setFontStretch(1);
+    m_hiddenMarkerFormat.setFontPointSize(1.0);
+
+    QFont hiddenFont = document() ? document()->defaultFont() : QFont();
+    hiddenFont.setPointSizeF(1.0);
+    const qreal charWidth = QFontMetricsF(hiddenFont).horizontalAdvance(QLatin1Char('['));
+
+    m_hiddenMarkerFormat.setFontLetterSpacingType(QFont::AbsoluteSpacing);
+    m_hiddenMarkerFormat.setFontLetterSpacing(-charWidth);
 
     m_headingFormat = QTextCharFormat();
     m_headingFormat.setForeground(text);

--- a/src/markdownhighlighter.h
+++ b/src/markdownhighlighter.h
@@ -11,6 +11,7 @@ public:
     explicit MarkdownHighlighter(QTextDocument *document);
 
     void setDarkMode(bool darkMode);
+    void setColors(const QString &background, const QString &foreground, const QString &accent);
     void setSearch(const QString &query, int currentMatchStart);
 
     struct Span {
@@ -41,6 +42,9 @@ private:
     void highlightSearch(const QString &text);
 
     bool m_darkMode = true;
+    QString m_customBackground;
+    QString m_customForeground;
+    QString m_customAccent;
     QTextCharFormat m_markerFormat;
     QTextCharFormat m_hiddenMarkerFormat;
     QTextCharFormat m_headingFormat;

--- a/src/systemtheme.cpp
+++ b/src/systemtheme.cpp
@@ -112,6 +112,8 @@ bool SystemTheme::portalDarkMode(bool *known) const {
     if (!settings.isValid())
         return false;
 
+    settings.setTimeout(150); // Prevent GUI thread freeze if the portal service hangs
+
     QDBusReply<QDBusVariant> reply = settings.call(
         QStringLiteral("Read"),
         QStringLiteral("org.freedesktop.appearance"),

--- a/src/systemtheme.cpp
+++ b/src/systemtheme.cpp
@@ -1,7 +1,7 @@
 #include "systemtheme.h"
 
 #include <QDBusConnection>
-#include <QDBusInterface>
+#include <QDBusMessage>
 #include <QDBusReply>
 #include <QDBusVariant>
 #include <QGuiApplication>
@@ -106,18 +106,19 @@ bool SystemTheme::detectDarkMode() const {
 bool SystemTheme::portalDarkMode(bool *known) const {
     *known = false;
 
-    QDBusInterface settings(QStringLiteral("org.freedesktop.portal.Desktop"),
-                            QStringLiteral("/org/freedesktop/portal/desktop"),
-                            QStringLiteral("org.freedesktop.portal.Settings"));
-    if (!settings.isValid())
+    const QDBusConnection bus = QDBusConnection::sessionBus();
+    if (!bus.isConnected())
         return false;
 
-    settings.setTimeout(150); // Prevent GUI thread freeze if the portal service hangs
-
-    QDBusReply<QDBusVariant> reply = settings.call(
-        QStringLiteral("Read"),
-        QStringLiteral("org.freedesktop.appearance"),
-        QStringLiteral("color-scheme"));
+    QDBusMessage request = QDBusMessage::createMethodCall(
+        QStringLiteral("org.freedesktop.portal.Desktop"),
+        QStringLiteral("/org/freedesktop/portal/desktop"),
+        QStringLiteral("org.freedesktop.portal.Settings"),
+        QStringLiteral("Read"));
+    request << QStringLiteral("org.freedesktop.appearance")
+            << QStringLiteral("color-scheme");
+    const QDBusReply<QDBusVariant> reply(
+        bus.call(request, QDBus::Block, 150));
     if (!reply.isValid())
         return false;
 

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -53,6 +53,40 @@ private slots:
         QCOMPARE(markup.at(2).markers[0].length, 1);
     }
 
+    void loadsCurrentOmarchyTheme() {
+        QTemporaryDir homeDirectory;
+        QVERIFY(homeDirectory.isValid());
+
+        const QByteArray originalHome = qgetenv("HOME");
+        struct HomeRestorer {
+            QByteArray value;
+            ~HomeRestorer() { qputenv("HOME", value); }
+        } restoreHome{originalHome};
+        QVERIFY(qputenv("HOME", homeDirectory.path().toUtf8()));
+
+        const QString themeDirectory = homeDirectory.path()
+            + QStringLiteral("/.local/state/omarchy/current/theme");
+        QVERIFY(QDir().mkpath(themeDirectory));
+
+        QFile colorsFile(themeDirectory + QStringLiteral("/colors.toml"));
+        QVERIFY(colorsFile.open(QIODevice::WriteOnly | QIODevice::Text));
+        const QByteArray palette(
+            "mode = \"light\"\n"
+            "accent = \"#112233\"\n"
+            "selection = \"#445566\"\n"
+            "background = \"#fefefe\"\n"
+            "foreground = \"#101010\"\n");
+        QCOMPARE(colorsFile.write(palette), qint64(palette.size()));
+        colorsFile.close();
+
+        Backend backend;
+        QCOMPARE(backend.themeBackground(), QStringLiteral("#fefefe"));
+        QCOMPARE(backend.themeForeground(), QStringLiteral("#101010"));
+        QCOMPARE(backend.themeAccent(), QStringLiteral("#112233"));
+        QCOMPARE(backend.themeSelection(), QStringLiteral("#445566"));
+        QVERIFY(!backend.darkMode());
+    }
+
     void ignoresFileWatcherEventsForSavedContents() {
         QTemporaryDir directory;
         QVERIFY(directory.isValid());


### PR DESCRIPTION
## Summary

- Prevent the portal color-scheme query from blocking startup by using a direct D-Bus call with a 150 ms timeout.
- Avoid Qt font-metrics deadlocks when pasting Markdown links by replacing sub-pixel marker formatting with negative absolute letter spacing.
- Sync editor, selection, accent, and unsaved-dialog colors with the active Omarchy palette and reload them when the theme changes.
- Read the current Omarchy palette from its state directory and honor its declared light/dark mode.

Link-paste fix demo:
https://github.com/user-attachments/assets/4dfb9c59-c082-47b5-9532-72e8d7730be1

Live-theme demo:
https://github.com/user-attachments/assets/2df88df4-290d-4129-b3b5-3d5b8b530a38

## Validation

- `./bin/build`
- `./bin/test` — 11 tests passed