### PR TITLE
Keep code literal and match its background to the theme

### DIFF
--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -371,6 +371,10 @@ QVariantList Backend::hiddenRangesAt(int position) const {
     if (!block.isValid())
         return ranges;
 
+    // The highlighter leaves fenced code alone, so it hides nothing there.
+    if (block.userState() == MarkdownHighlighter::InsideFence)
+        return ranges;
+
     const int lineStart = block.position();
     QList<QPair<int, int>> spans;
     const QList<MarkdownHighlighter::InlineMarkup> markup =

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -36,6 +36,17 @@
 constexpr qreal typoraLineHeightPercent = 140;
 const QString lastSaveDirectorySetting = QStringLiteral("file/lastSaveDirectory");
 
+namespace {
+
+// A shade of `from` carried part of the way towards `to`.
+QColor blend(const QColor &from, const QColor &to, qreal amount) {
+    return QColor::fromRgbF(from.redF() + (to.redF() - from.redF()) * amount,
+                            from.greenF() + (to.greenF() - from.greenF()) * amount,
+                            from.blueF() + (to.blueF() - from.blueF()) * amount);
+}
+
+}
+
 QString Backend::normalizedLinkUrl(const QString &clipboardText) {
     QString candidate = clipboardText.trimmed();
     static const QRegularExpression lineBreakRe(QStringLiteral("[\\r\\n]"));
@@ -180,7 +191,8 @@ void Backend::attachDocument(QObject *textDocument) {
     m_lastDocumentText = m_document->toPlainText();
     m_highlighter = new MarkdownHighlighter(m_document);
     m_highlighter->setDarkMode(m_darkMode);
-    m_highlighter->setColors(m_themeBackground, m_themeForeground, m_themeAccent);
+    m_highlighter->setColors(m_themeBackground, m_themeForeground, m_themeAccent,
+                             m_themeCodeBackground);
 
     connect(m_document, &QTextDocument::contentsChange, this,
             [this](int position, int, int charsAdded) {
@@ -582,6 +594,9 @@ void Backend::loadOmarchyTheme() {
     m_themeForeground = m_darkMode ? QStringLiteral("#eeeeee") : QStringLiteral("#222324");
     m_themeAccent = m_darkMode ? QStringLiteral("#5584aa") : QStringLiteral("#2077b2");
     m_themeSelection = m_darkMode ? QStringLiteral("#186a9a") : QStringLiteral("#2077b2");
+    // Left empty when the theme sets no lighter background; the highlighter
+    // mixes its own shade of the page in that case.
+    m_themeLighterBackground.clear();
 
     const QString colorsPath = QDir::homePath()
         + QStringLiteral("/.local/state/omarchy/current/theme/colors.toml");
@@ -615,6 +630,8 @@ void Backend::loadOmarchyTheme() {
                 m_themeAccent = value;
             else if (key == QStringLiteral("selection"))
                 m_themeSelection = value;
+            else if (key == QStringLiteral("lighter_background"))
+                m_themeLighterBackground = value;
         }
     }
 
@@ -640,9 +657,21 @@ void Backend::loadOmarchyTheme() {
         emit darkModeChanged();
     }
 
+    // Omarchy themes name a lighter background for panels like the one code
+    // sits on, so use the shade the theme chose. Not every theme sets the key,
+    // and a few set it to the page background, which would leave code with no
+    // panel at all: mix a shade of the page towards the text for those. Mixing,
+    // unlike lightening, still moves on a pure black background.
+    const QColor page(m_themeBackground);
+    const QColor lighter(m_themeLighterBackground);
+    m_themeCodeBackground = (lighter.isValid() && lighter != page
+                                 ? lighter
+                                 : blend(page, QColor(m_themeForeground), 0.06)).name();
+
     if (m_highlighter) {
         m_highlighter->setDarkMode(m_darkMode);
-        m_highlighter->setColors(m_themeBackground, m_themeForeground, m_themeAccent);
+        m_highlighter->setColors(m_themeBackground, m_themeForeground, m_themeAccent,
+                                 m_themeCodeBackground);
     }
 
     emit themeColorsChanged();

--- a/src/backend.h
+++ b/src/backend.h
@@ -28,6 +28,7 @@ class Backend : public QObject {
     Q_PROPERTY(QString themeForeground READ themeForeground NOTIFY themeColorsChanged)
     Q_PROPERTY(QString themeAccent READ themeAccent NOTIFY themeColorsChanged)
     Q_PROPERTY(QString themeSelection READ themeSelection NOTIFY themeColorsChanged)
+    Q_PROPERTY(QString themeCodeBackground READ themeCodeBackground NOTIFY themeColorsChanged)
 
 public:
     explicit Backend(QObject *parent = nullptr);
@@ -49,6 +50,7 @@ public:
     QString themeForeground() const { return m_themeForeground; }
     QString themeAccent() const { return m_themeAccent; }
     QString themeSelection() const { return m_themeSelection; }
+    QString themeCodeBackground() const { return m_themeCodeBackground; }
     static int countWords(const QString &text);
     static QString normalizedLinkUrl(const QString &clipboardText);
     static QString suggestedFileName(const QString &text);
@@ -139,5 +141,7 @@ private:
     QString m_themeForeground;
     QString m_themeAccent;
     QString m_themeSelection;
+    QString m_themeLighterBackground;
+    QString m_themeCodeBackground;
     QFileSystemWatcher m_themeWatcher;
 };

--- a/src/markdownhighlighter.cpp
+++ b/src/markdownhighlighter.cpp
@@ -178,14 +178,8 @@ void MarkdownHighlighter::highlightMarkers(const QString &text) {
 }
 
 void MarkdownHighlighter::highlightInline(const QString &text) {
-    if (text.contains(QLatin1Char('`'))) {
-        static const QRegularExpression codeRe(QStringLiteral("`([^`]+)`"));
-        QRegularExpressionMatchIterator codeMatches = codeRe.globalMatch(text);
-        while (codeMatches.hasNext()) {
-            const QRegularExpressionMatch match = codeMatches.next();
-            setFormat(match.capturedStart(0), match.capturedLength(0), m_codeFormat);
-        }
-    }
+    for (const Span &code : codeSpans(text))
+        setFormat(code.start, code.length, m_codeFormat);
 
     const QList<InlineMarkup> markup = inlineMarkup(text);
     for (const InlineMarkup &item : markup) {
@@ -199,6 +193,20 @@ void MarkdownHighlighter::highlightInline(const QString &text) {
     }
 }
 
+QList<MarkdownHighlighter::Span> MarkdownHighlighter::codeSpans(const QString &text) {
+    QList<Span> spans;
+    if (!text.contains(QLatin1Char('`')))
+        return spans;
+
+    static const QRegularExpression codeRe(QStringLiteral("`([^`]+)`"));
+    QRegularExpressionMatchIterator codeMatches = codeRe.globalMatch(text);
+    while (codeMatches.hasNext()) {
+        const QRegularExpressionMatch match = codeMatches.next();
+        spans.append({int(match.capturedStart(0)), int(match.capturedLength(0))});
+    }
+    return spans;
+}
+
 QList<MarkdownHighlighter::InlineMarkup> MarkdownHighlighter::inlineMarkup(const QString &text) {
     QList<InlineMarkup> markup;
     if (!text.contains(QLatin1Char('*')) && !text.contains(QLatin1Char('_'))
@@ -210,23 +218,46 @@ QList<MarkdownHighlighter::InlineMarkup> MarkdownHighlighter::inlineMarkup(const
         return Span{int(match.capturedStart(group)), int(match.capturedLength(group))};
     };
 
-    static const QRegularExpression boldRe(QStringLiteral("(\\*\\*|__)(.+?)(\\1)"));
+    // Inline code is literal, so a `*`, `_` or `[` inside backticks is not a
+    // marker: `default_line_height` keeps its underscores. Markup whose
+    // markers land in a code span is dropped; markup that merely wraps one
+    // (**bold with `code` inside**) still applies.
+    const QList<Span> code = codeSpans(text);
+    const auto append = [&](const InlineMarkup &item) {
+        for (const Span &span : code) {
+            for (const Span &marker : item.markers) {
+                if (marker.start < span.start + span.length
+                        && span.start < marker.start + marker.length)
+                    return;
+            }
+        }
+        markup.append(item);
+    };
+
+    // Underscores only delimit emphasis at a word boundary, so identifiers such
+    // as snake_case_name read as themselves. Asterisks delimit anywhere.
+    static const QRegularExpression boldRe(
+        QStringLiteral("\\*\\*(.+?)\\*\\*|(?<!\\w)__(.+?)__(?!\\w)"),
+        QRegularExpression::UseUnicodePropertiesOption);
     QRegularExpressionMatchIterator boldMatches = boldRe.globalMatch(text);
     while (boldMatches.hasNext()) {
         const QRegularExpressionMatch match = boldMatches.next();
-        markup.append({InlineKind::Bold, span(match, 2),
-                       {span(match, 1), span(match, 3)}});
+        const Span whole = span(match, 0);
+        const int contentIndex = match.capturedStart(1) >= 0 ? 1 : 2;
+        append({InlineKind::Bold, span(match, contentIndex),
+                {{whole.start, 2}, {whole.start + whole.length - 2, 2}}});
     }
 
     static const QRegularExpression italicRe(
-        QStringLiteral("(?<!\\*)\\*([^*\\n]+)\\*(?!\\*)|(?<!_)_([^_\\n]+)_(?!_)"));
+        QStringLiteral("(?<!\\*)\\*([^*\\n]+)\\*(?!\\*)|(?<!\\w)_([^_\\n]+)_(?!\\w)"),
+        QRegularExpression::UseUnicodePropertiesOption);
     QRegularExpressionMatchIterator italicMatches = italicRe.globalMatch(text);
     while (italicMatches.hasNext()) {
         const QRegularExpressionMatch match = italicMatches.next();
         const Span whole = span(match, 0);
         const int contentIndex = match.capturedStart(1) >= 0 ? 1 : 2;
-        markup.append({InlineKind::Italic, span(match, contentIndex),
-                       {{whole.start, 1}, {whole.start + whole.length - 1, 1}}});
+        append({InlineKind::Italic, span(match, contentIndex),
+                {{whole.start, 1}, {whole.start + whole.length - 1, 1}}});
     }
 
     static const QRegularExpression linkRe(
@@ -237,9 +268,9 @@ QList<MarkdownHighlighter::InlineMarkup> MarkdownHighlighter::inlineMarkup(const
         const Span whole = span(match, 0);
         const Span content = span(match, 1);
         const int contentEnd = content.start + content.length;
-        markup.append({InlineKind::Link, content,
-                       {{whole.start, 1},
-                        {contentEnd, whole.start + whole.length - contentEnd}}});
+        append({InlineKind::Link, content,
+                {{whole.start, 1},
+                 {contentEnd, whole.start + whole.length - contentEnd}}});
     }
 
     return markup;

--- a/src/markdownhighlighter.cpp
+++ b/src/markdownhighlighter.cpp
@@ -20,14 +20,15 @@ void MarkdownHighlighter::setDarkMode(bool darkMode) {
 }
 
 void MarkdownHighlighter::setColors(const QString &background, const QString &foreground,
-                                    const QString &accent) {
+                                    const QString &accent, const QString &codeBackground) {
     if (m_customBackground == background && m_customForeground == foreground
-            && m_customAccent == accent)
+            && m_customAccent == accent && m_customCodeBackground == codeBackground)
         return;
 
     m_customBackground = background;
     m_customForeground = foreground;
     m_customAccent = accent;
+    m_customCodeBackground = codeBackground;
     rebuildFormats();
     rehighlight();
 }
@@ -50,8 +51,9 @@ void MarkdownHighlighter::rebuildFormats() {
     const QColor link = !m_customAccent.isEmpty() ? QColor(m_customAccent)
         : (m_darkMode ? QColor(QStringLiteral("#5584aa")) : QColor(QStringLiteral("#2077b2")));
     const QColor quote = marker;
-    const QColor codeBackground = m_darkMode ? QColor(QStringLiteral("#1c1a1a"))
-                                             : QColor(QStringLiteral("#f8f8f8"));
+    const QColor codeBackground = !m_customCodeBackground.isEmpty()
+        ? QColor(m_customCodeBackground)
+        : (m_darkMode ? QColor(QStringLiteral("#1c1a1a")) : QColor(QStringLiteral("#f8f8f8")));
 
     m_markerFormat = QTextCharFormat();
     m_markerFormat.setForeground(marker);

--- a/src/markdownhighlighter.cpp
+++ b/src/markdownhighlighter.cpp
@@ -87,6 +87,10 @@ void MarkdownHighlighter::rebuildFormats() {
     m_codeFormat.setForeground(text);
     m_codeFormat.setBackground(codeBackground);
 
+    // A fence recedes the way a heading's `#` does, over the panel it opens.
+    m_fenceFormat = m_codeFormat;
+    m_fenceFormat.setForeground(marker);
+
     m_quoteFormat = QTextCharFormat();
     m_quoteFormat.setForeground(quote);
     m_quoteFormat.setFontItalic(true);
@@ -104,6 +108,19 @@ void MarkdownHighlighter::rebuildFormats() {
 }
 
 void MarkdownHighlighter::highlightBlock(const QString &text) {
+    // A fenced run of code is literal from its opening fence through its
+    // closing one, so no markup runs inside it. The state rides from block to
+    // block, and Qt rehighlights the rest of the document when it changes.
+    const bool fence = isFence(text);
+    const bool insideFence = previousBlockState() == InsideFence;
+    setCurrentBlockState(fence == insideFence ? Prose : InsideFence);
+
+    if (fence || insideFence) {
+        setFormat(0, text.length(), fence ? m_fenceFormat : m_codeFormat);
+        highlightSearch(text);
+        return;
+    }
+
     if (!text.isEmpty()) {
         highlightMarkers(text);
         if (text.contains(QLatin1Char('`')) || text.contains(QLatin1Char('*'))
@@ -112,6 +129,11 @@ void MarkdownHighlighter::highlightBlock(const QString &text) {
         }
     }
     highlightSearch(text);
+}
+
+bool MarkdownHighlighter::isFence(const QString &text) {
+    static const QRegularExpression fenceRe(QStringLiteral("^\\s*```"));
+    return text.contains(QLatin1Char('`')) && fenceRe.match(text).hasMatch();
 }
 
 void MarkdownHighlighter::highlightSearch(const QString &text) {

--- a/src/markdownhighlighter.h
+++ b/src/markdownhighlighter.h
@@ -11,7 +11,8 @@ public:
     explicit MarkdownHighlighter(QTextDocument *document);
 
     void setDarkMode(bool darkMode);
-    void setColors(const QString &background, const QString &foreground, const QString &accent);
+    void setColors(const QString &background, const QString &foreground, const QString &accent,
+                   const QString &codeBackground);
     void setSearch(const QString &query, int currentMatchStart);
 
     struct Span {
@@ -53,6 +54,7 @@ private:
     QString m_customBackground;
     QString m_customForeground;
     QString m_customAccent;
+    QString m_customCodeBackground;
     QTextCharFormat m_markerFormat;
     QTextCharFormat m_hiddenMarkerFormat;
     QTextCharFormat m_headingFormat;

--- a/src/markdownhighlighter.h
+++ b/src/markdownhighlighter.h
@@ -21,6 +21,10 @@ public:
 
     enum class InlineKind { Bold, Italic, Link };
 
+    // Carried from block to block so a fenced run of code knows it is inside
+    // one. Stored on the block, which is where Backend::hiddenRangesAt reads it.
+    enum BlockState { Prose = 0, InsideFence = 1 };
+
     struct InlineMarkup {
         InlineKind kind;
         Span content;
@@ -40,6 +44,7 @@ protected:
 
 private:
     void rebuildFormats();
+    static bool isFence(const QString &text);
     void highlightMarkers(const QString &text);
     void highlightInline(const QString &text);
     void highlightSearch(const QString &text);
@@ -54,6 +59,7 @@ private:
     QTextCharFormat m_boldFormat;
     QTextCharFormat m_italicFormat;
     QTextCharFormat m_codeFormat;
+    QTextCharFormat m_fenceFormat;
     QTextCharFormat m_quoteFormat;
     QTextCharFormat m_linkFormat;
     QString m_searchQuery;

--- a/src/markdownhighlighter.h
+++ b/src/markdownhighlighter.h
@@ -32,6 +32,9 @@ public:
     // Backend::hiddenRangesAt) to skip the caret over the hidden markers.
     static QList<InlineMarkup> inlineMarkup(const QString &text);
 
+    // Inline code spans, backticks included.
+    static QList<Span> codeSpans(const QString &text);
+
 protected:
     void highlightBlock(const QString &text) override;
 

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -54,6 +54,50 @@ private slots:
         QCOMPARE(markup.at(2).markers[0].length, 1);
     }
 
+    void leavesInlineCodeLiteral() {
+        QVERIFY(MarkdownHighlighter::inlineMarkup(
+                    QStringLiteral("see `default_line_height` and `file_name`")).isEmpty());
+        QVERIFY(MarkdownHighlighter::inlineMarkup(
+                    QStringLiteral("a_b `c_d`")).isEmpty());
+        // Word-boundary underscores inside a code span are still literal.
+        QVERIFY(MarkdownHighlighter::inlineMarkup(QStringLiteral("`_private_`")).isEmpty());
+        QVERIFY(MarkdownHighlighter::inlineMarkup(QStringLiteral("`a * b * c`")).isEmpty());
+        QVERIFY(MarkdownHighlighter::inlineMarkup(
+                    QStringLiteral("`[not](a link)`")).isEmpty());
+
+        // Emphasis that merely wraps a code span still applies.
+        const auto wrapping = MarkdownHighlighter::inlineMarkup(
+            QStringLiteral("**`file_name` only**"));
+        QCOMPARE(wrapping.size(), 1);
+        QCOMPARE(wrapping.at(0).kind, MarkdownHighlighter::InlineKind::Bold);
+        QCOMPARE(wrapping.at(0).content.start, 2);
+        QCOMPARE(wrapping.at(0).content.length, 16);
+        QCOMPARE(wrapping.at(0).markers[0].length, 2);
+        QCOMPARE(wrapping.at(0).markers[1].start, 18);
+    }
+
+    void keepsIntrawordUnderscoresLiteral() {
+        QVERIFY(MarkdownHighlighter::inlineMarkup(
+                    QStringLiteral("snake_case_name and default_line_height")).isEmpty());
+        QVERIFY(MarkdownHighlighter::inlineMarkup(QStringLiteral("a__b__c")).isEmpty());
+
+        // Emphasis still opens at a word boundary.
+        const auto underscoreBold =
+            MarkdownHighlighter::inlineMarkup(QStringLiteral("say __bold__ here"));
+        QCOMPARE(underscoreBold.size(), 1);
+        QCOMPARE(underscoreBold.at(0).content.start, 6);
+        QCOMPARE(underscoreBold.at(0).content.length, 4);
+
+        const auto emphasis = MarkdownHighlighter::inlineMarkup(
+            QStringLiteral("_italic_, **bold** and mid*word*"));
+        QCOMPARE(emphasis.size(), 3);
+        QCOMPARE(emphasis.at(0).kind, MarkdownHighlighter::InlineKind::Bold);
+        QCOMPARE(emphasis.at(0).content.length, 4);
+        QCOMPARE(emphasis.at(1).content.start, 1);
+        QCOMPARE(emphasis.at(1).content.length, 6);
+        QCOMPARE(emphasis.at(2).content.length, 4);
+    }
+
     void loadsCurrentOmarchyTheme() {
         QTemporaryDir homeDirectory;
         QVERIFY(homeDirectory.isValid());

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -139,6 +139,60 @@ private slots:
                             }));
     }
 
+    void takesTheCodePanelFromTheTheme() {
+        QTemporaryDir homeDirectory;
+        QVERIFY(homeDirectory.isValid());
+
+        const QByteArray originalHome = qgetenv("HOME");
+        struct HomeRestorer {
+            QByteArray value;
+            ~HomeRestorer() { qputenv("HOME", value); }
+        } restoreHome{originalHome};
+        QVERIFY(qputenv("HOME", homeDirectory.path().toUtf8()));
+
+        const QString themeDirectory = homeDirectory.path()
+            + QStringLiteral("/.local/state/omarchy/current/theme");
+        QVERIFY(QDir().mkpath(themeDirectory));
+
+        const auto codePanelFor = [&themeDirectory](const QByteArray &palette) {
+            QFile colorsFile(themeDirectory + QStringLiteral("/colors.toml"));
+            if (!colorsFile.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
+                return QColor();
+            colorsFile.write(palette);
+            colorsFile.close();
+            return QColor(Backend().themeCodeBackground());
+        };
+
+        // The shade the theme names for panels wins.
+        QCOMPARE(codePanelFor("mode = \"dark\"\n"
+                              "background = \"#111c18\"\n"
+                              "foreground = \"#c1c497\"\n"
+                              "lighter_background = \"#23372b\"\n"),
+                 QColor(QStringLiteral("#23372b")));
+
+        // Themes naming none leave code on a shade mixed from the page: a
+        // little off the background, and nowhere near the text.
+        const QColor mixedDark = codePanelFor("mode = \"dark\"\n"
+                                              "background = \"#000000\"\n"
+                                              "foreground = \"#ffffff\"\n");
+        QVERIFY(mixedDark != QColor(Qt::black));
+        QVERIFY(mixedDark.lightness() < 60);
+
+        const QColor mixedLight = codePanelFor("mode = \"light\"\n"
+                                               "background = \"#ffffff\"\n"
+                                               "foreground = \"#000000\"\n");
+        QVERIFY(mixedLight != QColor(Qt::white));
+        QVERIFY(mixedLight.lightness() > 195);
+
+        // A theme whose lighter background is the page itself would leave code
+        // with no panel at all, so it falls back to the mix as well.
+        QVERIFY(codePanelFor("mode = \"dark\"\n"
+                             "background = \"#0c0b0c\"\n"
+                             "foreground = \"#fafcfb\"\n"
+                             "lighter_background = \"#0c0b0c\"\n")
+                != QColor(QStringLiteral("#0c0b0c")));
+    }
+
     void loadsCurrentOmarchyTheme() {
         QTemporaryDir homeDirectory;
         QVERIFY(homeDirectory.isValid());

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -1,5 +1,7 @@
 #include <QtTest>
 #include <QFont>
+#include <QTextDocument>
+#include <QTextLayout>
 #include <QQmlComponent>
 #include <QQmlContext>
 #include <QQmlEngine>
@@ -96,6 +98,45 @@ private slots:
         QCOMPARE(emphasis.at(1).content.start, 1);
         QCOMPARE(emphasis.at(1).content.length, 6);
         QCOMPARE(emphasis.at(2).content.length, 4);
+    }
+
+    void leavesFencedCodeLiteral() {
+        QTextDocument document;
+        document.setPlainText(QStringLiteral("prose _italic_\n"
+                                            "```ruby\n"
+                                            "snake_case_name = *value*\n"
+                                            "```\n"
+                                            "after _italic_\n"));
+        MarkdownHighlighter highlighter(&document);
+        highlighter.rehighlight();
+
+        const auto stateOf = [&document](int blockNumber) {
+            return document.findBlockByNumber(blockNumber).userState();
+        };
+        QCOMPARE(stateOf(0), int(MarkdownHighlighter::Prose));
+        QCOMPARE(stateOf(1), int(MarkdownHighlighter::InsideFence));
+        QCOMPARE(stateOf(2), int(MarkdownHighlighter::InsideFence));
+        QCOMPARE(stateOf(3), int(MarkdownHighlighter::Prose));
+        QCOMPARE(stateOf(4), int(MarkdownHighlighter::Prose));
+
+        // The fenced line sits on the code panel, with nothing italic and no
+        // marker hidden.
+        const QList<QTextLayout::FormatRange> fenced =
+            document.findBlockByNumber(2).layout()->formats();
+        QCOMPARE(fenced.size(), 1);
+        QCOMPARE(fenced.constFirst().length, document.findBlockByNumber(2).text().length());
+        QVERIFY(fenced.constFirst().format.background().style() != Qt::NoBrush);
+        for (const QTextLayout::FormatRange &range : fenced) {
+            QVERIFY(!range.format.fontItalic());
+            QVERIFY(range.format.foreground().color() != range.format.background().color());
+        }
+
+        const QList<QTextLayout::FormatRange> prose =
+            document.findBlockByNumber(4).layout()->formats();
+        QVERIFY(std::any_of(prose.cbegin(), prose.cend(),
+                            [](const QTextLayout::FormatRange &range) {
+                                return range.format.fontItalic();
+                            }));
     }
 
     void loadsCurrentOmarchyTheme() {


### PR DESCRIPTION
Code containing Markdown characters was being styled as prose: `default_line_height` lost its underscores to italics, `*value*` inside a fenced block became emphasis, and the caret skipped visible characters as though they were hidden markup.

Treat inline code and triple-backtick fenced blocks as literal text, using the same parsing for highlighting and caret movement. Preserve underscores inside identifiers in ordinary prose. Emphasis and links can still surround inline code, while the code keeps its own styling and background. Escaped opening backticks stay literal, and closing fence lines no longer report hidden markers.

Code backgrounds now use the Omarchy theme's `lighter_background`. If that value is missing, invalid, or identical to the page background, Backend mixes the page color 6% toward the text color. This also works on pure black and white pages, and reloading a theme cannot retain the previous theme's panel color.

### Validation

- Rebased onto current master (`8f98892`).
- `QT_QPA_PLATFORMTHEME=generic bin/test`: 21 passed, 0 failed on Qt 6.11.2.
- `bin/build` builds the application.
- Regression coverage includes escaped backticks, code inside bold/italic/link text, caret ranges on opening/interior/closing fence lines, unterminated fences and fence deletion, and theme color selection and fallback across reloads.

The inline-code portion overlaps with #48 and includes the same code-last rendering order needed to preserve nested code styling. This PR also handles underscores in prose, fenced blocks, and theme-derived code backgrounds.

The existing parser remains limited to single-backtick inline spans and the editor's triple-backtick fence convention. Fence backgrounds are painted per character, so their right edges follow line lengths and empty lines have no panel.
