### PR TITLE
Outdent heading markers

### DIFF
--- a/src/Main.qml
+++ b/src/Main.qml
@@ -430,10 +430,8 @@ ApplicationWindow {
                 objectName: "sourceEditor"
                 readonly property real bodyWidth: Math.min(
                     win.editorWidth, Math.max(1, editorFlick.width - win.headingGutterWidth))
-                readonly property real bodyX: Math.max(
-                    win.headingGutterWidth,
-                    Math.round((editorFlick.width - bodyWidth) / 2))
-                x: bodyX - win.headingGutterWidth
+                x: Math.max(0, Math.round((editorFlick.width - bodyWidth) / 2)
+                            - win.headingGutterWidth)
                 y: Math.max(42, Math.round(win.height * 0.05))
                 width: bodyWidth + win.headingGutterWidth
                 height: Math.max(editorFlick.height - y - 96, implicitHeight + 20)

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -29,6 +29,8 @@ ApplicationWindow {
     readonly property int editorWidth: Math.min(
         Math.round(writerFontMetrics.averageCharacterWidth * 65),
         Math.max(360, width - Math.round(writerFontMetrics.averageCharacterWidth * 20)))
+    readonly property real headingCellWidth: writerFontMetrics.averageCharacterWidth
+    readonly property real headingGutterWidth: headingCellWidth * 7
     property bool closeConfirmed: false
     property bool searchOpen: false
     property bool searchUpdating: false
@@ -42,6 +44,8 @@ ApplicationWindow {
     Material.theme: darkMode ? Material.Dark : Material.Light
     Material.accent: backend.themeAccent
     color: pageColor
+
+    onHeadingCellWidthChanged: backend.setHeadingCellWidth(headingCellWidth)
 
     onClosing: function(close) {
         if (closeConfirmed || !backend.modified)
@@ -424,9 +428,14 @@ ApplicationWindow {
             TextEdit {
                 id: editor
                 objectName: "sourceEditor"
-                x: Math.round((editorFlick.width - width) / 2)
+                readonly property real bodyWidth: Math.min(
+                    win.editorWidth, Math.max(1, editorFlick.width - win.headingGutterWidth))
+                readonly property real bodyX: Math.max(
+                    win.headingGutterWidth,
+                    Math.round((editorFlick.width - bodyWidth) / 2))
+                x: bodyX - win.headingGutterWidth
                 y: Math.max(42, Math.round(win.height * 0.05))
-                width: win.editorWidth
+                width: bodyWidth + win.headingGutterWidth
                 height: Math.max(editorFlick.height - y - 96, implicitHeight + 20)
                 text: ""
                 textFormat: TextEdit.PlainText
@@ -451,6 +460,15 @@ ApplicationWindow {
                     var start = Math.min(selectionStart, selectionEnd);
                     var end = Math.max(selectionStart, selectionEnd);
                     EditorMutations.replaceRange(editor, start, end, replacement);
+                }
+
+                function refreshCursorAfterHeading() {
+                    // Qt's edit cursor can retain the heading's inherited indent
+                    // after the new empty block has already been reformatted.
+                    var position = cursorPosition;
+                    if (position > 0)
+                        cursorPosition = position - 1;
+                    cursorPosition = position;
                 }
 
                 function wrapSelection(before, after) {
@@ -486,12 +504,15 @@ ApplicationWindow {
                 }
 
                 function smartReturn(softBreak) {
-                    if (softBreak) {
-                        replaceSelectionWith("\n");
-                        return;
-                    }
                     var lineStart = text.lastIndexOf("\n", cursorPosition - 1) + 1;
                     var line = text.slice(lineStart, cursorPosition);
+                    var leavingHeading = /^#{1,6}\s/.test(line);
+                    if (softBreak) {
+                        replaceSelectionWith("\n");
+                        if (leavingHeading)
+                            refreshCursorAfterHeading();
+                        return;
+                    }
                     var before = text.slice(0, cursorPosition);
                     var fences = (before.match(/^\s*```/gm) || []).length;
                     if ((fences % 2) === 1) {
@@ -512,6 +533,8 @@ ApplicationWindow {
                         return;
                     }
                     replaceSelectionWith("\n\n");
+                    if (leavingHeading)
+                        refreshCursorAfterHeading();
                 }
 
                 function escapeMarkdownLinkText(linkText) {
@@ -668,6 +691,7 @@ ApplicationWindow {
                 Text {
                     anchors.left: parent.left
                     anchors.top: parent.top
+                    anchors.leftMargin: win.headingGutterWidth - win.headingCellWidth * 2
                     text: "# Start writing"
                     visible: editor.text.length === 0 && !editor.activeFocus
                     color: win.mutedColor
@@ -677,6 +701,7 @@ ApplicationWindow {
                 }
 
                 Component.onCompleted: {
+                    backend.setHeadingCellWidth(win.headingCellWidth);
                     backend.attachDocument(textDocument);
                     forceActiveFocus();
                 }

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -461,12 +461,11 @@ ApplicationWindow {
                 }
 
                 function refreshCursorAfterHeading() {
-                    // Qt's edit cursor can retain the heading's inherited indent
-                    // after the new empty block has already been reformatted.
-                    var position = cursorPosition;
-                    if (position > 0)
-                        cursorPosition = position - 1;
-                    cursorPosition = position;
+                    // Recalculate the cursor x-position after leaving a heading block.
+                    var originalPosition = cursorPosition;
+                    if (originalPosition > 0)
+                        cursorPosition = originalPosition - 1;
+                    cursorPosition = originalPosition;
                 }
 
                 function wrapSelection(before, after) {

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -215,13 +215,13 @@ ApplicationWindow {
     Shortcut {
         sequence: "Ctrl+Z"
         context: Qt.WindowShortcut
-        onActivated: editor.undo()
+        onActivated: editor.undoDocument()
     }
 
     Shortcut {
         sequences: ["Ctrl+Shift+Z", "Ctrl+Y"]
         context: Qt.WindowShortcut
-        onActivated: editor.redo()
+        onActivated: editor.redoDocument()
     }
 
     Shortcut {
@@ -454,6 +454,14 @@ ApplicationWindow {
                 }
                 onCursorRectangleChanged: editorFlick.ensureCursorVisible()
 
+                function undoDocument() {
+                    backend.undo(editor);
+                }
+
+                function redoDocument() {
+                    backend.redo(editor);
+                }
+
                 function replaceSelectionWith(replacement) {
                     var start = Math.min(selectionStart, selectionEnd);
                     var end = Math.max(selectionStart, selectionEnd);
@@ -640,6 +648,17 @@ ApplicationWindow {
 
                 Keys.priority: Keys.BeforeItem
                 Keys.onPressed: function(event) {
+                    if (event.matches(StandardKey.Undo)) {
+                        undoDocument();
+                        event.accepted = true;
+                        return;
+                    }
+                    if (event.matches(StandardKey.Redo)) {
+                        redoDocument();
+                        event.accepted = true;
+                        return;
+                    }
+
                     var pasteKey = (event.key === Qt.Key_V)
                         && (event.modifiers & Qt.ControlModifier)
                         && !(event.modifiers & (Qt.AltModifier | Qt.MetaModifier | Qt.ShiftModifier));

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -194,19 +194,22 @@ void Backend::attachDocument(QObject *textDocument) {
     restoreRecovery();
 }
 
-bool Backend::documentTypographyMatches() const {
+QTextBlockFormat Backend::blockFormatWithTypography(const QTextBlock &block) const {
+    const MarkdownHighlighter::HeadingMarkup heading =
+        MarkdownHighlighter::headingMarkup(block.text());
+    QTextBlockFormat format = block.blockFormat();
+    format.setLineHeight(typoraLineHeightPercent, QTextBlockFormat::ProportionalHeight);
+    format.setLeftMargin(m_headingCellWidth * 7);
+    format.setTextIndent(heading.isValid() ? -m_headingCellWidth * (heading.level + 1) : 0);
+    return format;
+}
+
+bool Backend::documentHasExpectedTypography() const {
     if (!m_document)
         return true;
 
     for (QTextBlock block = m_document->begin(); block.isValid(); block = block.next()) {
-        const MarkdownHighlighter::HeadingMarkup heading =
-            MarkdownHighlighter::headingMarkup(block.text());
-        QTextBlockFormat expected = block.blockFormat();
-        expected.setLineHeight(typoraLineHeightPercent, QTextBlockFormat::ProportionalHeight);
-        expected.setLeftMargin(m_headingCellWidth * 7);
-        expected.setTextIndent(heading.isValid()
-                                   ? -m_headingCellWidth * (heading.level + 1) : 0);
-        if (expected != block.blockFormat())
+        if (block.blockFormat() != blockFormatWithTypography(block))
             return false;
     }
     return true;
@@ -398,11 +401,18 @@ void Backend::replayHistory(QObject *editor, bool redo) {
     const QScopedValueRollback historyChange(m_historyChange, true);
     const QString previousText = currentDocumentText();
     const char *action = redo ? "redo" : "undo";
-    do {
-        QMetaObject::invokeMethod(editor, action, Qt::DirectConnection);
-    } while ((redo ? m_document->isRedoAvailable() : m_document->isUndoAvailable())
-             && (currentDocumentText() == previousText
-                 || (redo && !documentTypographyMatches())));
+
+    // Typography can occupy its own history entry. Consume those entries so
+    // each user action reaches one visible text edit with the right formatting.
+    while (redo ? m_document->isRedoAvailable() : m_document->isUndoAvailable()) {
+        if (!QMetaObject::invokeMethod(editor, action, Qt::DirectConnection))
+            return;
+
+        const bool textChanged = currentDocumentText() != previousText;
+        const bool typographyRestored = !redo || documentHasExpectedTypography();
+        if (textChanged && typographyRestored)
+            return;
+    }
 }
 
 QVariantList Backend::hiddenRangesAt(int position) const {
@@ -816,13 +826,8 @@ void Backend::reapplyTypographyToChange() {
 }
 
 void Backend::updateBlockTypography(QTextCursor &cursor, const QTextBlock &block) const {
-    const MarkdownHighlighter::HeadingMarkup heading =
-        MarkdownHighlighter::headingMarkup(block.text());
     const QTextBlockFormat current = block.blockFormat();
-    QTextBlockFormat format = current;
-    format.setLineHeight(typoraLineHeightPercent, QTextBlockFormat::ProportionalHeight);
-    format.setLeftMargin(m_headingCellWidth * 7);
-    format.setTextIndent(heading.isValid() ? -m_headingCellWidth * (heading.level + 1) : 0);
+    const QTextBlockFormat format = blockFormatWithTypography(block);
     if (format == current)
         return;
 

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -198,7 +198,7 @@ void Backend::setHeadingCellWidth(qreal width) {
         return;
 
     m_headingCellWidth = width;
-    updateAllBlockTypography();
+    updateAllBlocksTypography();
 }
 
 void Backend::openDialog() {
@@ -730,12 +730,12 @@ void Backend::applyDocumentTypography() {
     const bool undoEnabled = m_document->isUndoRedoEnabled();
     m_document->setUndoRedoEnabled(false);
 
-    updateAllBlockTypography();
+    updateAllBlocksTypography();
 
     m_document->setUndoRedoEnabled(undoEnabled);
 }
 
-void Backend::updateAllBlockTypography() {
+void Backend::updateAllBlocksTypography() {
     if (!m_document)
         return;
 

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -30,16 +30,10 @@
 #include <QWindow>
 
 #include <algorithm>
-#include <cmath>
-
 #include "markdownhighlighter.h"
 
 constexpr qreal typoraLineHeightPercent = 140;
 const QString lastSaveDirectorySetting = QStringLiteral("file/lastSaveDirectory");
-
-bool nearlyEqual(qreal left, qreal right) {
-    return qAbs(left - right) < 0.01;
-}
 
 QString Backend::normalizedLinkUrl(const QString &clipboardText) {
     QString candidate = clipboardText.trimmed();
@@ -200,11 +194,11 @@ void Backend::attachDocument(QObject *textDocument) {
 }
 
 void Backend::setHeadingCellWidth(qreal width) {
-    if (!std::isfinite(width) || width <= 0 || nearlyEqual(width, m_headingCellWidth))
+    if (width == m_headingCellWidth)
         return;
 
     m_headingCellWidth = width;
-    reapplyTypographyToAllBlocks();
+    updateAllBlockTypography();
 }
 
 void Backend::openDialog() {
@@ -736,18 +730,12 @@ void Backend::applyDocumentTypography() {
     const bool undoEnabled = m_document->isUndoRedoEnabled();
     m_document->setUndoRedoEnabled(false);
 
-    m_formattingTypography = true;
-    QTextCursor cursor(m_document);
-    cursor.beginEditBlock();
-    for (QTextBlock block = m_document->begin(); block.isValid(); block = block.next())
-        updateBlockTypography(cursor, block);
-    cursor.endEditBlock();
-    m_formattingTypography = false;
+    updateAllBlockTypography();
 
     m_document->setUndoRedoEnabled(undoEnabled);
 }
 
-void Backend::reapplyTypographyToAllBlocks() {
+void Backend::updateAllBlockTypography() {
     if (!m_document)
         return;
 
@@ -787,23 +775,16 @@ void Backend::reapplyTypographyToChange() {
 }
 
 void Backend::updateBlockTypography(QTextCursor &cursor, const QTextBlock &block) const {
-    const QTextBlockFormat current = block.blockFormat();
     const MarkdownHighlighter::HeadingMarkup heading =
         MarkdownHighlighter::headingMarkup(block.text());
-    const qreal gutter = m_headingCellWidth * 7;
-    const qreal indent = heading.isValid() ? -m_headingCellWidth * (heading.level + 1) : 0;
-
-    const bool needsUpdate = current.lineHeightType() != QTextBlockFormat::ProportionalHeight
-        || !nearlyEqual(current.lineHeight(), typoraLineHeightPercent)
-        || !nearlyEqual(current.leftMargin(), gutter)
-        || !nearlyEqual(current.textIndent(), indent);
-    if (!needsUpdate)
+    const QTextBlockFormat current = block.blockFormat();
+    QTextBlockFormat format = current;
+    format.setLineHeight(typoraLineHeightPercent, QTextBlockFormat::ProportionalHeight);
+    format.setLeftMargin(m_headingCellWidth * 7);
+    format.setTextIndent(heading.isValid() ? -m_headingCellWidth * (heading.level + 1) : 0);
+    if (format == current)
         return;
 
-    QTextBlockFormat format;
-    format.setLineHeight(typoraLineHeightPercent, QTextBlockFormat::ProportionalHeight);
-    format.setLeftMargin(gutter);
-    format.setTextIndent(indent);
     cursor.setPosition(block.position());
-    cursor.mergeBlockFormat(format);
+    cursor.setBlockFormat(format);
 }

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -20,6 +20,7 @@
 #include <QJsonObject>
 #include <QLockFile>
 #include <QSaveFile>
+#include <QScopedValueRollback>
 #include <QTextBlock>
 #include <QTextBlockFormat>
 #include <QTextCursor>
@@ -193,6 +194,24 @@ void Backend::attachDocument(QObject *textDocument) {
     restoreRecovery();
 }
 
+bool Backend::documentTypographyMatches() const {
+    if (!m_document)
+        return true;
+
+    for (QTextBlock block = m_document->begin(); block.isValid(); block = block.next()) {
+        const MarkdownHighlighter::HeadingMarkup heading =
+            MarkdownHighlighter::headingMarkup(block.text());
+        QTextBlockFormat expected = block.blockFormat();
+        expected.setLineHeight(typoraLineHeightPercent, QTextBlockFormat::ProportionalHeight);
+        expected.setLeftMargin(m_headingCellWidth * 7);
+        expected.setTextIndent(heading.isValid()
+                                   ? -m_headingCellWidth * (heading.level + 1) : 0);
+        if (expected != block.blockFormat())
+            return false;
+    }
+    return true;
+}
+
 void Backend::setHeadingCellWidth(qreal width) {
     if (width == m_headingCellWidth)
         return;
@@ -354,7 +373,7 @@ bool Backend::editorTextChanged() {
         return false;
     m_lastDocumentText = text;
 
-    if (m_document)
+    if (m_document && !m_historyChange)
         reapplyTypographyToChange();
 
     scheduleWordCount();
@@ -362,6 +381,28 @@ bool Backend::editorTextChanged() {
     setStatus(QStringLiteral("Unsaved"));
     scheduleRecovery();
     return true;
+}
+
+void Backend::undo(QObject *editor) {
+    replayHistory(editor, false);
+}
+
+void Backend::redo(QObject *editor) {
+    replayHistory(editor, true);
+}
+
+void Backend::replayHistory(QObject *editor, bool redo) {
+    if (!editor || !m_document)
+        return;
+
+    const QScopedValueRollback historyChange(m_historyChange, true);
+    const QString previousText = currentDocumentText();
+    const char *action = redo ? "redo" : "undo";
+    do {
+        QMetaObject::invokeMethod(editor, action, Qt::DirectConnection);
+    } while ((redo ? m_document->isRedoAvailable() : m_document->isUndoAvailable())
+             && (currentDocumentText() == previousText
+                 || (redo && !documentTypographyMatches())));
 }
 
 QVariantList Backend::hiddenRangesAt(int position) const {

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -30,11 +30,16 @@
 #include <QWindow>
 
 #include <algorithm>
+#include <cmath>
 
 #include "markdownhighlighter.h"
 
 constexpr qreal typoraLineHeightPercent = 140;
 const QString lastSaveDirectorySetting = QStringLiteral("file/lastSaveDirectory");
+
+bool nearlyEqual(qreal left, qreal right) {
+    return qAbs(left - right) < 0.01;
+}
 
 QString Backend::normalizedLinkUrl(const QString &clipboardText) {
     QString candidate = clipboardText.trimmed();
@@ -194,6 +199,14 @@ void Backend::attachDocument(QObject *textDocument) {
     restoreRecovery();
 }
 
+void Backend::setHeadingCellWidth(qreal width) {
+    if (!std::isfinite(width) || width <= 0 || nearlyEqual(width, m_headingCellWidth))
+        return;
+
+    m_headingCellWidth = width;
+    reapplyTypographyToAllBlocks();
+}
+
 void Backend::openDialog() {
     emit openDialogRequested();
 }
@@ -347,12 +360,8 @@ bool Backend::editorTextChanged() {
         return false;
     m_lastDocumentText = text;
 
-    if (m_document) {
-        const int blockCount = m_document->blockCount();
-        if (blockCount > m_formattedBlockCount)
-            reapplyTypographyToChange();
-        m_formattedBlockCount = blockCount;
-    }
+    if (m_document)
+        reapplyTypographyToChange();
 
     scheduleWordCount();
     setModified(true);
@@ -722,9 +731,6 @@ void Backend::applyDocumentTypography() {
     if (!m_document)
         return;
 
-    QTextBlockFormat blockFormat;
-    blockFormat.setLineHeight(typoraLineHeightPercent, QTextBlockFormat::ProportionalHeight);
-
     // A full pass is only used for freshly loaded/attached documents, so it is
     // safe to drop undo history here (re-enabling clears the stack anyway).
     const bool undoEnabled = m_document->isUndoRedoEnabled();
@@ -732,21 +738,31 @@ void Backend::applyDocumentTypography() {
 
     m_formattingTypography = true;
     QTextCursor cursor(m_document);
-    cursor.select(QTextCursor::Document);
-    cursor.mergeBlockFormat(blockFormat);
+    cursor.beginEditBlock();
+    for (QTextBlock block = m_document->begin(); block.isValid(); block = block.next())
+        updateBlockTypography(cursor, block);
+    cursor.endEditBlock();
     m_formattingTypography = false;
 
     m_document->setUndoRedoEnabled(undoEnabled);
+}
 
-    m_formattedBlockCount = m_document->blockCount();
+void Backend::reapplyTypographyToAllBlocks() {
+    if (!m_document)
+        return;
+
+    m_formattingTypography = true;
+    QTextCursor cursor(m_document);
+    cursor.beginEditBlock();
+    for (QTextBlock block = m_document->begin(); block.isValid(); block = block.next())
+        updateBlockTypography(cursor, block);
+    cursor.endEditBlock();
+    m_formattingTypography = false;
 }
 
 void Backend::reapplyTypographyToChange() {
     if (!m_document)
         return;
-
-    QTextBlockFormat blockFormat;
-    blockFormat.setLineHeight(typoraLineHeightPercent, QTextBlockFormat::ProportionalHeight);
 
     // Format only the block(s) touched by the last edit instead of the whole
     // document, and fold the change into the preceding edit command so a single
@@ -755,12 +771,39 @@ void Backend::reapplyTypographyToChange() {
     const int start = qBound(0, m_lastChangePos, maxPos);
     const int end = qBound(start, m_lastChangePos + m_lastChangeAdded, maxPos);
 
+    const QTextBlock firstBlock = m_document->findBlock(start);
+    const QTextBlock lastBlock = m_document->findBlock(end);
+
     m_formattingTypography = true;
     QTextCursor cursor(m_document);
     cursor.joinPreviousEditBlock();
-    cursor.setPosition(start);
-    cursor.setPosition(end, QTextCursor::KeepAnchor);
-    cursor.mergeBlockFormat(blockFormat);
+    for (QTextBlock block = firstBlock; block.isValid(); block = block.next()) {
+        updateBlockTypography(cursor, block);
+        if (block == lastBlock)
+            break;
+    }
     cursor.endEditBlock();
     m_formattingTypography = false;
+}
+
+void Backend::updateBlockTypography(QTextCursor &cursor, const QTextBlock &block) const {
+    const QTextBlockFormat current = block.blockFormat();
+    const MarkdownHighlighter::HeadingMarkup heading =
+        MarkdownHighlighter::headingMarkup(block.text());
+    const qreal gutter = m_headingCellWidth * 7;
+    const qreal indent = heading.isValid() ? -m_headingCellWidth * (heading.level + 1) : 0;
+
+    const bool needsUpdate = current.lineHeightType() != QTextBlockFormat::ProportionalHeight
+        || !nearlyEqual(current.lineHeight(), typoraLineHeightPercent)
+        || !nearlyEqual(current.leftMargin(), gutter)
+        || !nearlyEqual(current.textIndent(), indent);
+    if (!needsUpdate)
+        return;
+
+    QTextBlockFormat format;
+    format.setLineHeight(typoraLineHeightPercent, QTextBlockFormat::ProportionalHeight);
+    format.setLeftMargin(gutter);
+    format.setTextIndent(indent);
+    cursor.setPosition(block.position());
+    cursor.mergeBlockFormat(format);
 }

--- a/src/backend.h
+++ b/src/backend.h
@@ -104,7 +104,7 @@ private:
     void refreshWordCount();
     void scheduleWordCount();
     void applyDocumentTypography();
-    void reapplyTypographyToAllBlocks();
+    void updateAllBlockTypography();
     void reapplyTypographyToChange();
     void updateBlockTypography(QTextCursor &cursor, const QTextBlock &block) const;
     void scheduleRecovery();

--- a/src/backend.h
+++ b/src/backend.h
@@ -104,7 +104,7 @@ private:
     void refreshWordCount();
     void scheduleWordCount();
     void applyDocumentTypography();
-    void updateAllBlockTypography();
+    void updateAllBlocksTypography();
     void reapplyTypographyToChange();
     void updateBlockTypography(QTextCursor &cursor, const QTextBlock &block) const;
     void scheduleRecovery();

--- a/src/backend.h
+++ b/src/backend.h
@@ -72,6 +72,8 @@ public:
     Q_INVOKABLE QString clipboardUrl() const;
     Q_INVOKABLE QString clipboardText() const;
     Q_INVOKABLE bool editorTextChanged();
+    Q_INVOKABLE void undo(QObject *editor);
+    Q_INVOKABLE void redo(QObject *editor);
     Q_INVOKABLE QVariantList hiddenRangesAt(int position) const;
     Q_INVOKABLE void setSearchHighlight(const QString &query, int currentMatchStart);
     Q_INVOKABLE void openExternalUrl(const QUrl &url);
@@ -104,6 +106,8 @@ private:
     void refreshWordCount();
     void scheduleWordCount();
     void applyDocumentTypography();
+    bool documentTypographyMatches() const;
+    void replayHistory(QObject *editor, bool redo);
     void updateAllBlocksTypography();
     void reapplyTypographyToChange();
     void updateBlockTypography(QTextCursor &cursor, const QTextBlock &block) const;
@@ -125,6 +129,7 @@ private:
     bool m_loading = false;
     bool m_closeAfterSave = false;
     bool m_formattingTypography = false;
+    bool m_historyChange = false;
     int m_lastChangePos = 0;
     int m_lastChangeAdded = 0;
     qreal m_headingCellWidth = 0;

--- a/src/backend.h
+++ b/src/backend.h
@@ -11,6 +11,8 @@
 #include <memory>
 
 class MarkdownHighlighter;
+class QTextBlock;
+class QTextCursor;
 class QTextDocument;
 class QWindow;
 class QLockFile;
@@ -54,6 +56,7 @@ public:
     static QString suggestedFileName(const QString &text);
 
     Q_INVOKABLE void attachDocument(QObject *textDocument);
+    Q_INVOKABLE void setHeadingCellWidth(qreal width);
     Q_INVOKABLE void openDialog();
     Q_INVOKABLE void open(const QUrl &url);
     Q_INVOKABLE void save();
@@ -101,7 +104,9 @@ private:
     void refreshWordCount();
     void scheduleWordCount();
     void applyDocumentTypography();
+    void reapplyTypographyToAllBlocks();
     void reapplyTypographyToChange();
+    void updateBlockTypography(QTextCursor &cursor, const QTextBlock &block) const;
     void scheduleRecovery();
     void writeRecovery();
     void restoreRecovery();
@@ -120,9 +125,9 @@ private:
     bool m_loading = false;
     bool m_closeAfterSave = false;
     bool m_formattingTypography = false;
-    int m_formattedBlockCount = 0;
     int m_lastChangePos = 0;
     int m_lastChangeAdded = 0;
+    qreal m_headingCellWidth = 0;
     QTimer m_wordCountTimer;
     QTimer m_recoveryTimer;
     QFileSystemWatcher m_fileWatcher;

--- a/src/backend.h
+++ b/src/backend.h
@@ -12,6 +12,7 @@
 
 class MarkdownHighlighter;
 class QTextBlock;
+class QTextBlockFormat;
 class QTextCursor;
 class QTextDocument;
 class QWindow;
@@ -106,7 +107,8 @@ private:
     void refreshWordCount();
     void scheduleWordCount();
     void applyDocumentTypography();
-    bool documentTypographyMatches() const;
+    QTextBlockFormat blockFormatWithTypography(const QTextBlock &block) const;
+    bool documentHasExpectedTypography() const;
     void replayHistory(QObject *editor, bool redo);
     void updateAllBlocksTypography();
     void reapplyTypographyToChange();

--- a/src/markdownhighlighter.cpp
+++ b/src/markdownhighlighter.cpp
@@ -139,13 +139,10 @@ void MarkdownHighlighter::highlightMarkers(const QString &text) {
 
     const QChar firstChar = text.at(first);
     if (first == 0 && firstChar == QLatin1Char('#')) {
-        static const QRegularExpression headingRe(QStringLiteral("^(#{1,6})(\\s+)(.*)$"));
-        const QRegularExpressionMatch heading = headingRe.match(text);
-        if (heading.hasMatch()) {
-            setFormat(0, heading.capturedLength(1) + heading.capturedLength(2),
-                      m_markerFormat);
-            setFormat(heading.capturedStart(3), heading.capturedLength(3),
-                      m_headingFormat);
+        const HeadingMarkup heading = headingMarkup(text);
+        if (heading.isValid()) {
+            setFormat(heading.marker.start, heading.marker.length, m_markerFormat);
+            setFormat(heading.content.start, heading.content.length, m_headingFormat);
             return;
         }
     }
@@ -175,6 +172,21 @@ void MarkdownHighlighter::highlightMarkers(const QString &text) {
         if (rule.hasMatch())
             setFormat(0, text.length(), m_markerFormat);
     }
+}
+
+MarkdownHighlighter::HeadingMarkup MarkdownHighlighter::headingMarkup(const QString &text) {
+    if (!text.startsWith(QLatin1Char('#')))
+        return {};
+
+    static const QRegularExpression headingRe(QStringLiteral("^(#{1,6})(\\s+)(.*)$"));
+    const QRegularExpressionMatch heading = headingRe.match(text);
+    if (!heading.hasMatch())
+        return {};
+
+    const int markerLength = heading.capturedLength(1) + heading.capturedLength(2);
+    return {int(heading.capturedLength(1)),
+            {0, markerLength},
+            {int(heading.capturedStart(3)), int(heading.capturedLength(3))}};
 }
 
 void MarkdownHighlighter::highlightInline(const QString &text) {

--- a/src/markdownhighlighter.cpp
+++ b/src/markdownhighlighter.cpp
@@ -131,6 +131,13 @@ void MarkdownHighlighter::highlightSearch(const QString &text) {
 }
 
 void MarkdownHighlighter::highlightMarkers(const QString &text) {
+    const HeadingMarkup heading = headingMarkup(text);
+    if (heading.isValid()) {
+        setFormat(0, heading.prefixLength, m_markerFormat);
+        setFormat(heading.prefixLength, text.length() - heading.prefixLength, m_headingFormat);
+        return;
+    }
+
     int first = 0;
     while (first < text.length() && text.at(first).isSpace())
         ++first;
@@ -138,15 +145,6 @@ void MarkdownHighlighter::highlightMarkers(const QString &text) {
         return;
 
     const QChar firstChar = text.at(first);
-    if (first == 0 && firstChar == QLatin1Char('#')) {
-        const HeadingMarkup heading = headingMarkup(text);
-        if (heading.isValid()) {
-            setFormat(heading.marker.start, heading.marker.length, m_markerFormat);
-            setFormat(heading.content.start, heading.content.length, m_headingFormat);
-            return;
-        }
-    }
-
     if (firstChar == QLatin1Char('>')) {
         static const QRegularExpression quoteRe(QStringLiteral("^(\\s*>+\\s?)(.*)$"));
         const QRegularExpressionMatch quote = quoteRe.match(text);
@@ -183,10 +181,7 @@ MarkdownHighlighter::HeadingMarkup MarkdownHighlighter::headingMarkup(const QStr
     if (!heading.hasMatch())
         return {};
 
-    const int markerLength = heading.capturedLength(1) + heading.capturedLength(2);
-    return {int(heading.capturedLength(1)),
-            {0, markerLength},
-            {int(heading.capturedStart(3)), int(heading.capturedLength(3))}};
+    return {int(heading.capturedLength(1)), int(heading.capturedStart(3))};
 }
 
 void MarkdownHighlighter::highlightInline(const QString &text) {

--- a/src/markdownhighlighter.h
+++ b/src/markdownhighlighter.h
@@ -31,7 +31,7 @@ public:
         int level = 0;
         int prefixLength = 0;
 
-        bool isValid() const { return level > 0; }
+        bool isValid() const { return level > 0 && level <= 6; }
     };
 
     // Single source of truth for inline markdown spans: the highlighter uses it

--- a/src/markdownhighlighter.h
+++ b/src/markdownhighlighter.h
@@ -29,8 +29,7 @@ public:
 
     struct HeadingMarkup {
         int level = 0;
-        Span marker{0, 0};
-        Span content{0, 0};
+        int prefixLength = 0;
 
         bool isValid() const { return level > 0; }
     };

--- a/src/markdownhighlighter.h
+++ b/src/markdownhighlighter.h
@@ -27,10 +27,19 @@ public:
         Span markers[2];
     };
 
+    struct HeadingMarkup {
+        int level = 0;
+        Span marker{0, 0};
+        Span content{0, 0};
+
+        bool isValid() const { return level > 0; }
+    };
+
     // Single source of truth for inline markdown spans: the highlighter uses it
     // to style content and hide markers, and the editor uses it (via
     // Backend::hiddenRangesAt) to skip the caret over the hidden markers.
     static QList<InlineMarkup> inlineMarkup(const QString &text);
+    static HeadingMarkup headingMarkup(const QString &text);
 
 protected:
     void highlightBlock(const QString &text) override;

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -295,6 +295,58 @@ private slots:
                 <= editorParent->property("width").toReal() + 0.01);
     }
 
+    void undoingHeadingDoesNotExposeTypographyStep() {
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        Backend backend;
+        QQmlEngine engine;
+        engine.rootContext()->setContextProperty(QStringLiteral("backend"), &backend);
+        QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> window(component.create());
+        QVERIFY2(window, qPrintable(component.errorString()));
+
+        QObject *editor = window->findChild<QObject *>(QStringLiteral("sourceEditor"));
+        QVERIFY(editor);
+        auto *quickDocument = editor->property("textDocument").value<QQuickTextDocument *>();
+        QVERIFY(quickDocument);
+        QTextDocument *document = quickDocument->textDocument();
+        QVERIFY(document);
+
+        editor->setProperty("cursorPosition", 0);
+        QVERIFY(QMetaObject::invokeMethod(editor, "insert",
+                                         Q_ARG(int, 0),
+                                         Q_ARG(QString, QStringLiteral("### Heading"))));
+        QVERIFY(QMetaObject::invokeMethod(editor, "smartReturn",
+                                         Q_ARG(QVariant, QVariant(false))));
+        editor->setProperty("cursorPosition", editor->property("text").toString().size());
+        QVERIFY(QMetaObject::invokeMethod(editor, "replaceSelectionWith",
+                                         Q_ARG(QVariant, QVariant(QStringLiteral("body")))));
+
+        QKeyEvent undoEvent(QEvent::KeyPress, Qt::Key_Z, Qt::ControlModifier);
+        QCoreApplication::sendEvent(editor, &undoEvent);
+        QVERIFY(undoEvent.isAccepted());
+        QCOMPARE(editor->property("text").toString(), QStringLiteral("### Heading\n\n"));
+        QVERIFY(QMetaObject::invokeMethod(editor, "undoDocument"));
+        QCOMPARE(editor->property("text").toString(), QStringLiteral("### Heading"));
+        const qreal expectedIndent = -window->property("headingCellWidth").toReal() * 4;
+        QVERIFY(qAbs(document->begin().blockFormat().textIndent() - expectedIndent) < 0.01);
+        QVERIFY(QMetaObject::invokeMethod(editor, "undoDocument"));
+        QCOMPARE(editor->property("text").toString(), QString());
+
+        for (int i = 0; i < 2; ++i) {
+            editor->setProperty("cursorPosition", editor->property("text").toString().size());
+            QVERIFY(QMetaObject::invokeMethod(editor, "undoDocument"));
+            QCoreApplication::processEvents();
+            QCOMPARE(editor->property("text").toString(), QString());
+        }
+
+        QVERIFY(QMetaObject::invokeMethod(editor, "redoDocument"));
+        QCOMPARE(editor->property("text").toString(), QStringLiteral("### Heading"));
+        QVERIFY(qAbs(document->begin().blockFormat().textIndent() - expectedIndent) < 0.01);
+    }
+
     void remembersLastSaveDirectory() {
         QTemporaryDir saveDirectory;
         QVERIFY(saveDirectory.isValid());

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -69,6 +69,8 @@ private slots:
         QVERIFY(!MarkdownHighlighter::headingMarkup(QStringLiteral("####### Heading")).isValid());
         QVERIFY(!MarkdownHighlighter::headingMarkup(QStringLiteral("#Heading")).isValid());
         QVERIFY(!MarkdownHighlighter::headingMarkup(QStringLiteral(" # Heading")).isValid());
+        const MarkdownHighlighter::HeadingMarkup invalidLevel{7, 8};
+        QVERIFY(!invalidLevel.isValid());
     }
 
     void loadsCurrentOmarchyTheme() {

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -63,8 +63,7 @@ private slots:
             const auto heading = MarkdownHighlighter::headingMarkup(
                 prefix + QStringLiteral(" Heading"));
             QCOMPARE(heading.level, level);
-            QCOMPARE(heading.marker.length, level + 1);
-            QCOMPARE(heading.content.start, level + 1);
+            QCOMPARE(heading.prefixLength, level + 1);
         }
 
         QVERIFY(!MarkdownHighlighter::headingMarkup(QStringLiteral("####### Heading")).isValid());

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -3,7 +3,10 @@
 #include <QQmlComponent>
 #include <QQmlContext>
 #include <QQmlEngine>
+#include <QQuickTextDocument>
 #include <QQuickStyle>
+#include <QTextBlock>
+#include <QTextDocument>
 
 #include "backend.h"
 #include "markdownhighlighter.h"
@@ -52,6 +55,21 @@ private slots:
         QCOMPARE(markup.at(0).content.length, 4);
         QCOMPARE(markup.at(2).content.length, 4);
         QCOMPARE(markup.at(2).markers[0].length, 1);
+    }
+
+    void findsMarkdownHeadings() {
+        for (int level = 1; level <= 6; ++level) {
+            const QString prefix(level, QLatin1Char('#'));
+            const auto heading = MarkdownHighlighter::headingMarkup(
+                prefix + QStringLiteral(" Heading"));
+            QCOMPARE(heading.level, level);
+            QCOMPARE(heading.marker.length, level + 1);
+            QCOMPARE(heading.content.start, level + 1);
+        }
+
+        QVERIFY(!MarkdownHighlighter::headingMarkup(QStringLiteral("####### Heading")).isValid());
+        QVERIFY(!MarkdownHighlighter::headingMarkup(QStringLiteral("#Heading")).isValid());
+        QVERIFY(!MarkdownHighlighter::headingMarkup(QStringLiteral(" # Heading")).isValid());
     }
 
     void loadsCurrentOmarchyTheme() {
@@ -216,6 +234,64 @@ private slots:
         backend.setTextScale(9.0 / 12.0);
         QCOMPARE(window->property("editorFontPixelSize").toInt(), 15);
         QCOMPARE(editor->property("font").value<QFont>().pixelSize(), 15);
+    }
+
+    void laysOutAndEditsHeadings() {
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        Backend backend;
+        QQmlEngine engine;
+        engine.rootContext()->setContextProperty(QStringLiteral("backend"), &backend);
+        QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> window(component.create());
+        QVERIFY2(window, qPrintable(component.errorString()));
+
+        QObject *editor = window->findChild<QObject *>(QStringLiteral("sourceEditor"));
+        QVERIFY(editor);
+        auto *quickDocument = editor->property("textDocument").value<QQuickTextDocument *>();
+        QVERIFY(quickDocument);
+        QTextDocument *document = quickDocument->textDocument();
+        QVERIFY(document);
+
+        editor->setProperty("text", QStringLiteral("Body\nBody"));
+        editor->setProperty("cursorPosition", 0);
+        QCoreApplication::processEvents();
+        const qreal bodyCursorX = editor->property("cursorRectangle").toRectF().x();
+
+        editor->setProperty("text", QStringLiteral("## Heading\nBody"));
+        const QTextBlock heading = document->begin();
+        const QTextBlock body = heading.next();
+        const qreal gutter = window->property("headingGutterWidth").toReal();
+        const qreal expectedPrefixWidth = window->property("headingCellWidth").toReal() * 3;
+        QVERIFY(qAbs(heading.blockFormat().leftMargin() - gutter) < 0.01);
+        QVERIFY(qAbs(heading.blockFormat().textIndent() + expectedPrefixWidth) < 0.01);
+        QCOMPARE(body.blockFormat().textIndent(), 0.0);
+
+        editor->setProperty("text", QStringLiteral("Heading\nBody"));
+        QCOMPARE(document->begin().blockFormat().textIndent(), 0.0);
+
+        editor->setProperty("text", QStringLiteral("### Heading"));
+        editor->setProperty("cursorPosition", editor->property("text").toString().size());
+        QVERIFY(QMetaObject::invokeMethod(editor, "smartReturn",
+                                         Q_ARG(QVariant, QVariant(false))));
+        QCOMPARE(editor->property("text").toString(), QStringLiteral("### Heading\n\n"));
+        QVERIFY(qAbs(editor->property("cursorRectangle").toRectF().x() - bodyCursorX) < 0.01);
+
+        editor->setProperty("text", QStringLiteral("###### Heading"));
+        const qreal initialGutter = window->property("headingGutterWidth").toReal();
+        backend.setTextScale(3.0);
+        window->setProperty("width", 720);
+        QTRY_VERIFY(window->property("headingGutterWidth").toReal() > initialGutter);
+
+        const qreal scaledGutter = window->property("headingGutterWidth").toReal();
+        QTRY_VERIFY(qAbs(document->begin().blockFormat().leftMargin() - scaledGutter) < 0.01);
+        QVERIFY(editor->property("x").toReal() >= 0);
+        QObject *editorParent = editor->parent();
+        QVERIFY(editorParent);
+        QVERIFY(editor->property("x").toReal() + editor->property("width").toReal()
+                <= editorParent->property("width").toReal() + 0.01);
     }
 
     void remembersLastSaveDirectory() {


### PR DESCRIPTION
## Reason for Changes

I personally find it more visually pleasing to have Markdown heading markers (like `###`) outdented, while keeping the actual heading text aligned with regular paragraphs.

Feel free to use my implementation if it aligns with your vision for the app. Here's a screenshot for comparison:

<img width="2873" height="1098" alt="screenshot-2026-08-08_14-35-05" src="https://github.com/user-attachments/assets/9608d0dd-d2e5-404e-8eca-e3882a16fa4c" />

## Tests

Here's the list of tests I performed manually:

* verified that various real-world notes render correctly (copied from my Obsidian vault)
* resized the window from fullscreen to very small and tested all states in between
* repeatedly changed the Omarchy monitor scaling
* verified that Markdown headings above level 6 are not formatted
* verified undo/redo behavior

## Implementation approach

* I asked GPT-5.6 Sol to implement the initial version
* Then went through multiple iterations of manual review (done by me) and fixes (done by Sol) until the implementation felt reasonably simple IMO
* Performed manual testing and made some additional fixes, mostly around undo/redo behavior
