### PR TITLE
Fix false "unsaved changes" prompt when a document is reverted to its original state

### DIFF
--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -114,10 +114,10 @@ Backend::Backend(QObject *parent) : QObject(parent) {
                     }
                 }
 
-                if (!deleted) {
-                    m_hasKnownFileContents = false;
-                    m_lastKnownFileText.clear();
-                }
+                // Whatever is on disk now, it is not what we last read, so the
+                // baseline is unknown until the writer picks a version. A
+                // deletion counts: the old text is not saved anywhere either.
+                setKnownFileContents(QByteArray(), false);
                 emit externalChangeDetected(deleted, m_modified);
             });
 
@@ -358,8 +358,13 @@ bool Backend::editorTextChanged() {
     scheduleWordCount();
 
     const QString &baseline = m_lastKnownFileText;
+    // An empty baseline means a pristine untitled document, but only when there
+    // is no file behind it. Once there is one, an unknown baseline is unknown
+    // rather than empty, and emptying the editor is a change like any other.
+    const bool baselineKnown = m_hasKnownFileContents
+        || !m_fileUrl.isValid() || m_fileUrl.isEmpty();
 
-    if (text == baseline) {
+    if (baselineKnown && text == baseline) {
         setModified(false);
         clearRecovery();
         if (m_hasKnownFileContents)

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -114,8 +114,10 @@ Backend::Backend(QObject *parent) : QObject(parent) {
                     }
                 }
 
-                if (!deleted)
+                if (!deleted) {
                     m_hasKnownFileContents = false;
+                    m_lastKnownFileText.clear();
+                }
                 emit externalChangeDetected(deleted, m_modified);
             });
 
@@ -216,8 +218,7 @@ void Backend::open(const QUrl &url) {
     const QByteArray contents = file.readAll();
     loadDocumentText(QString::fromUtf8(contents));
     clearRecovery();
-    m_lastKnownFileContents = contents;
-    m_hasKnownFileContents = true;
+    setKnownFileContents(contents, true);
     setFileUrl(url);
     watchCurrentFile();
     setModified(false);
@@ -267,11 +268,9 @@ void Backend::reloadFromDisk() {
 void Backend::keepExternalVersion() {
     QFile file(m_fileUrl.toLocalFile());
     if (file.open(QIODevice::ReadOnly)) {
-        m_lastKnownFileContents = file.readAll();
-        m_hasKnownFileContents = true;
+        setKnownFileContents(file.readAll(), true);
     } else {
-        m_lastKnownFileContents.clear();
-        m_hasKnownFileContents = false;
+        setKnownFileContents(QByteArray(), false);
     }
     setModified(true);
     scheduleRecovery();
@@ -358,10 +357,7 @@ bool Backend::editorTextChanged() {
 
     scheduleWordCount();
 
-    const QString baseline = m_hasKnownFileContents
-        ? QString::fromUtf8(m_lastKnownFileContents)
-              .replace(QStringLiteral("\r\n"), QStringLiteral("\n"))
-        : QString();
+    const QString &baseline = m_lastKnownFileText;
 
     if (text == baseline) {
         setModified(false);
@@ -516,8 +512,7 @@ void Backend::saveTo(const QUrl &url) {
 
     const bool shouldClose = m_closeAfterSave;
     m_closeAfterSave = false;
-    m_lastKnownFileContents = contents;
-    m_hasKnownFileContents = true;
+    setKnownFileContents(contents, true);
     setFileUrl(url);
     watchCurrentFile();
     QSettings().setValue(lastSaveDirectorySetting,
@@ -537,6 +532,14 @@ void Backend::scheduleRecovery() {
 
 QString Backend::recoveryPath() const {
     return m_recoveryPath;
+}
+
+void Backend::setKnownFileContents(const QByteArray &contents, bool known) {
+    m_lastKnownFileContents = contents;
+    m_hasKnownFileContents = known;
+    m_lastKnownFileText = known
+        ? QString::fromUtf8(contents).replace(QStringLiteral("\r\n"), QStringLiteral("\n"))
+        : QString();
 }
 
 void Backend::writeRecovery() {
@@ -567,11 +570,9 @@ void Backend::restoreRecovery() {
     const QUrl recoveredUrl(recovery.value(QStringLiteral("fileUrl")).toString());
     QFile diskFile(recoveredUrl.toLocalFile());
     if (recoveredUrl.isLocalFile() && diskFile.open(QIODevice::ReadOnly)) {
-        m_lastKnownFileContents = diskFile.readAll();
-        m_hasKnownFileContents = true;
+        setKnownFileContents(diskFile.readAll(), true);
     } else {
-        m_lastKnownFileContents.clear();
-        m_hasKnownFileContents = false;
+        setKnownFileContents(QByteArray(), false);
     }
     setFileUrl(recoveredUrl);
     setModified(true);

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -114,6 +114,8 @@ Backend::Backend(QObject *parent) : QObject(parent) {
                     }
                 }
 
+                if (!deleted)
+                    m_hasKnownFileContents = false;
                 emit externalChangeDetected(deleted, m_modified);
             });
 
@@ -355,9 +357,25 @@ bool Backend::editorTextChanged() {
     }
 
     scheduleWordCount();
-    setModified(true);
-    setStatus(QStringLiteral("Unsaved"));
-    scheduleRecovery();
+
+    const QString baseline = m_hasKnownFileContents
+        ? QString::fromUtf8(m_lastKnownFileContents)
+              .replace(QStringLiteral("\r\n"), QStringLiteral("\n"))
+        : QString();
+
+    if (text == baseline) {
+        setModified(false);
+        clearRecovery();
+        if (m_hasKnownFileContents)
+            setStatus(QStringLiteral("Saved %1").arg(fileName()));
+        else
+            setStatus(QString());
+    } else {
+        setModified(true);
+        setStatus(QStringLiteral("Unsaved"));
+        scheduleRecovery();
+    }
+
     return true;
 }
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -107,6 +107,7 @@ private:
     void restoreRecovery();
     void clearRecovery();
     QString recoveryPath() const;
+    void setKnownFileContents(const QByteArray &contents, bool known);
     void watchCurrentFile();
     void loadOmarchyTheme();
     void watchOmarchyTheme();
@@ -131,6 +132,7 @@ private:
     QPointer<MarkdownHighlighter> m_highlighter;
     QString m_lastDocumentText;
     QByteArray m_lastKnownFileContents;
+    QString m_lastKnownFileText;
     bool m_hasKnownFileContents = false;
     QString m_recoveryPath;
     std::unique_ptr<QLockFile> m_recoveryLock;

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -292,6 +292,42 @@ private slots:
         QVERIFY(!backend.modified());
     }
 
+    void keepsADocumentUnsavedAfterItsFileDisappears() {
+        QTemporaryDir directory;
+        QVERIFY(directory.isValid());
+
+        const QString path = directory.filePath(QStringLiteral("gone.md"));
+        QFile file(path);
+        QVERIFY(file.open(QIODevice::WriteOnly | QIODevice::Text));
+        QCOMPARE(file.write("hello"), qint64(5));
+        file.close();
+
+        Backend backend;
+        QQuickTextDocument *quickDocument = attachTextEdit(&backend);
+        QVERIFY(quickDocument);
+
+        QSignalSpy externalChangeSpy(&backend, &Backend::externalChangeDetected);
+        backend.open(QUrl::fromLocalFile(path));
+        QVERIFY(!backend.modified());
+
+        QVERIFY(QFile::remove(path));
+        QTRY_COMPARE(externalChangeSpy.count(), 1);
+
+        // The writer can dismiss the dialog without picking a version, so the
+        // text the deleted file used to hold is not a saved state to return to.
+        quickDocument->textDocument()->setPlainText(QStringLiteral("hello world"));
+        QVERIFY(backend.editorTextChanged());
+        quickDocument->textDocument()->setPlainText(QStringLiteral("hello"));
+        QVERIFY(backend.editorTextChanged());
+        QVERIFY(backend.modified());
+
+        // Nor is emptying it: an empty document only reads as clean while there
+        // is no file behind it.
+        quickDocument->textDocument()->setPlainText(QString());
+        QVERIFY(backend.editorTextChanged());
+        QVERIFY(backend.modified());
+    }
+
 private:
     // Loads a bare TextEdit, attaches its document to the backend, and returns
     // the QQuickTextDocument. The engine and TextEdit are parented to the

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -4,6 +4,9 @@
 #include <QQmlContext>
 #include <QQmlEngine>
 #include <QQuickStyle>
+#include <QQuickTextDocument>
+#include <QStandardPaths>
+#include <QTextDocument>
 
 #include "backend.h"
 #include "markdownhighlighter.h"
@@ -13,6 +16,7 @@ class OmawriteTest : public QObject {
 
 private slots:
     void initTestCase() {
+        QStandardPaths::setTestModeEnabled(true);
         QVERIFY(m_settingsDirectory.isValid());
         QQuickStyle::setStyle(QStringLiteral("Material"));
         QSettings::setDefaultFormat(QSettings::IniFormat);
@@ -246,7 +250,76 @@ private slots:
         QCOMPARE(QFileInfo(fallbackUrl.toLocalFile()).absolutePath(), QDir::homePath());
     }
 
+    void revertsEmptyDocumentToCleanState() {
+        Backend backend;
+        QQuickTextDocument *quickDocument = attachTextEdit(&backend);
+        QVERIFY(quickDocument);
+
+        QVERIFY(!backend.modified());
+
+        quickDocument->textDocument()->setPlainText(QStringLiteral("hello"));
+        QVERIFY(backend.editorTextChanged());
+        QVERIFY(backend.modified());
+
+        quickDocument->textDocument()->setPlainText(QString());
+        QVERIFY(backend.editorTextChanged());
+        QVERIFY(!backend.modified());
+    }
+
+    void revertsSavedDocumentToCleanState() {
+        QTemporaryDir directory;
+        QVERIFY(directory.isValid());
+
+        const QString path = directory.filePath(QStringLiteral("doc.md"));
+        QFile file(path);
+        QVERIFY(file.open(QIODevice::WriteOnly | QIODevice::Text));
+        QCOMPARE(file.write("hello"), qint64(5));
+        file.close();
+
+        Backend backend;
+        QQuickTextDocument *quickDocument = attachTextEdit(&backend);
+        QVERIFY(quickDocument);
+
+        backend.open(QUrl::fromLocalFile(path));
+        QVERIFY(!backend.modified());
+
+        quickDocument->textDocument()->setPlainText(QStringLiteral("hello world"));
+        QVERIFY(backend.editorTextChanged());
+        QVERIFY(backend.modified());
+
+        quickDocument->textDocument()->setPlainText(QStringLiteral("hello"));
+        QVERIFY(backend.editorTextChanged());
+        QVERIFY(!backend.modified());
+    }
+
 private:
+    // Loads a bare TextEdit, attaches its document to the backend, and returns
+    // the QQuickTextDocument. The engine and TextEdit are parented to the
+    // backend so they outlive the helper call.
+    QQuickTextDocument *attachTextEdit(Backend *backend) {
+        auto *engine = new QQmlEngine(backend);
+        auto *component = new QQmlComponent(engine);
+        component->setData(R"QML(
+            import QtQuick
+            TextEdit { }
+        )QML", QUrl::fromLocalFile(QStringLiteral("Harness.qml")));
+        if (!component->isReady())
+            return nullptr;
+
+        QObject *editor = component->create();
+        if (!editor)
+            return nullptr;
+        editor->setParent(backend);
+
+        auto *quickDocument = qobject_cast<QQuickTextDocument *>(
+            editor->property("textDocument").value<QObject *>());
+        if (!quickDocument)
+            return nullptr;
+
+        backend->attachDocument(quickDocument);
+        return quickDocument;
+    }
+
     QTemporaryDir m_settingsDirectory;
 };
 


### PR DESCRIPTION
**Summary**

Fix the false "unsaved changes" prompt when a document is reverted to its original state.

- Fixes #4 + the same unsaved changes behavior on existing files.
- Added two regression tests in tests/tst_omawrite.cpp:
  - revertsEmptyDocumentToCleanState() — typing then deleting all text on a new document.
  - revertsSavedDocumentToCleanState() — editing an opened file then reverting to its saved contents.

**Details**

Backend::editorTextChanged() set the modified flag whenever the editor text differed from the last known text, but never cleared it when the text returned to its baseline. Typing text and then deleting it back to the original content left modified = true, so closing the window prompted to save changes that didn't exist.

**Fix**

editorTextChanged() now compares the current text against a baseline (the on-disk contents, or an empty string for a new file) and clears the modified flag when they match.