### PR TITLE
Add a Ctrl+Shift+X strikethrough shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install via the Omarchy Package Repository via the `omawrite` package. It's inst
 - `Super+F` toggles fullscreen. Qt maps this key as `Meta+F`.
 - `Ctrl+F` searches the document. Use `Enter` or `Ctrl+G` for the next match and `Shift+Enter` for the previous match.
 - `Ctrl+H` opens find and replace.
-- `Ctrl+B`, `Ctrl+I`, and `Ctrl+K` insert bold, italic, and link Markdown.
+- `Ctrl+B`, `Ctrl+I`, and `Ctrl+Shift+X` toggle bold, italic, and strikethrough Markdown. `Ctrl+K` inserts a link.
 - `Ctrl+?` shows the keyboard shortcut reference.
 
 Unsaved drafts are recovered after an abnormal exit. Omawrite also watches open files

--- a/src/EditorMutations.js
+++ b/src/EditorMutations.js
@@ -4,6 +4,32 @@ function normalizePlainText(text) {
     return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
+function toggleWrap(editor, before, after) {
+    var start = Math.min(editor.selectionStart, editor.selectionEnd);
+    var end = Math.max(editor.selectionStart, editor.selectionEnd);
+    var selected = editor.text.slice(start, end);
+
+    // Selection includes the markers: strip them.
+    if (selected.length >= before.length + after.length
+            && selected.startsWith(before) && selected.endsWith(after)) {
+        var inner = selected.slice(before.length, selected.length - after.length);
+        replaceRange(editor, start, end, inner, 0, inner.length);
+        return;
+    }
+
+    // Selection (or caret) sits directly inside the markers: strip them.
+    if (start >= before.length
+            && editor.text.slice(start - before.length, start) === before
+            && editor.text.slice(end, end + after.length) === after) {
+        replaceRange(editor, start - before.length, end + after.length, selected,
+                     0, selected.length);
+        return;
+    }
+
+    replaceRange(editor, start, end, before + selected + after,
+                 before.length, before.length + selected.length);
+}
+
 function replaceRange(editor, rangeStart, rangeEnd, replacement,
                       selectionStartOffset, selectionEndOffset) {
     var start = Math.max(0, Math.min(editor.text.length, rangeStart));

--- a/src/EditorMutations.js
+++ b/src/EditorMutations.js
@@ -9,9 +9,16 @@ function toggleWrap(editor, before, after) {
     var end = Math.max(editor.selectionStart, editor.selectionEnd);
     var selected = editor.text.slice(start, end);
 
+    // "*" is also the first half of "**", so a marker is only ours to strip
+    // when it is a whole run rather than part of a longer one.
+    var openChar = before.charAt(0);
+    var closeChar = after.charAt(after.length - 1);
+
     // Selection includes the markers: strip them.
     if (selected.length >= before.length + after.length
-            && selected.startsWith(before) && selected.endsWith(after)) {
+            && selected.startsWith(before) && selected.endsWith(after)
+            && selected.charAt(before.length) !== openChar
+            && selected.charAt(selected.length - after.length - 1) !== closeChar) {
         var inner = selected.slice(before.length, selected.length - after.length);
         replaceRange(editor, start, end, inner, 0, inner.length);
         return;
@@ -20,7 +27,9 @@ function toggleWrap(editor, before, after) {
     // Selection (or caret) sits directly inside the markers: strip them.
     if (start >= before.length
             && editor.text.slice(start - before.length, start) === before
-            && editor.text.slice(end, end + after.length) === after) {
+            && editor.text.slice(end, end + after.length) === after
+            && editor.text.charAt(start - before.length - 1) !== openChar
+            && editor.text.charAt(end + after.length) !== closeChar) {
         replaceRange(editor, start - before.length, end + after.length, selected,
                      0, selected.length);
         return;

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -167,6 +167,12 @@ ApplicationWindow {
     }
 
     Shortcut {
+        sequence: "Ctrl+Shift+X"
+        context: Qt.WindowShortcut
+        onActivated: editor.wrapSelection("~~", "~~")
+    }
+
+    Shortcut {
         sequence: "Ctrl+K"
         context: Qt.WindowShortcut
         onActivated: editor.insertLink()
@@ -331,7 +337,7 @@ ApplicationWindow {
         standardButtons: Dialog.Close
         anchors.centerIn: parent
         contentItem: Label {
-            text: "Ctrl+S  Save\nCtrl+Shift+S  Save As\nCtrl+O  Open\nCtrl+N  New Window\nCtrl+F  Find\nCtrl+H  Find and Replace\nCtrl+B  Bold\nCtrl+I  Italic\nCtrl+K  Link\nCtrl+P  Print\nF11 / Super+F  Fullscreen\nCtrl+?  Shortcuts"
+            text: "Ctrl+S  Save\nCtrl+Shift+S  Save As\nCtrl+O  Open\nCtrl+N  New Window\nCtrl+F  Find\nCtrl+H  Find and Replace\nCtrl+B  Bold\nCtrl+I  Italic\nCtrl+Shift+X  Strikethrough\nCtrl+K  Link\nCtrl+P  Print\nF11 / Super+F  Fullscreen\nCtrl+?  Shortcuts"
             lineHeight: 1.5
         }
     }
@@ -568,13 +574,7 @@ ApplicationWindow {
 
                 function wrapSelection(before, after) {
                     forceActiveFocus();
-                    var start = Math.min(selectionStart, selectionEnd);
-                    var end = Math.max(selectionStart, selectionEnd);
-                    var selected = text.slice(start, end);
-                    EditorMutations.replaceRange(editor, start, end,
-                                                 before + selected + after,
-                                                 before.length,
-                                                 before.length + selected.length);
+                    EditorMutations.toggleWrap(editor, before, after);
                 }
 
                 function insertLink() {

--- a/src/markdownhighlighter.cpp
+++ b/src/markdownhighlighter.cpp
@@ -83,6 +83,10 @@ void MarkdownHighlighter::rebuildFormats() {
     m_italicFormat.setFontItalic(true);
     m_italicFormat.setForeground(text);
 
+    m_strikethroughFormat = QTextCharFormat();
+    m_strikethroughFormat.setFontStrikeOut(true);
+    m_strikethroughFormat.setForeground(text);
+
     m_codeFormat = QTextCharFormat();
     m_codeFormat.setForeground(text);
     m_codeFormat.setBackground(codeBackground);
@@ -107,7 +111,8 @@ void MarkdownHighlighter::highlightBlock(const QString &text) {
     if (!text.isEmpty()) {
         highlightMarkers(text);
         if (text.contains(QLatin1Char('`')) || text.contains(QLatin1Char('*'))
-            || text.contains(QLatin1Char('_')) || text.contains(QLatin1Char('['))) {
+            || text.contains(QLatin1Char('_')) || text.contains(QLatin1Char('['))
+            || text.contains(QLatin1Char('~'))) {
             highlightInline(text);
         }
     }
@@ -192,7 +197,8 @@ void MarkdownHighlighter::highlightInline(const QString &text) {
         const QTextCharFormat &contentFormat =
             item.kind == InlineKind::Bold ? m_boldFormat
             : item.kind == InlineKind::Italic ? m_italicFormat
-                                              : m_linkFormat;
+            : item.kind == InlineKind::Strikethrough ? m_strikethroughFormat
+                                                     : m_linkFormat;
         setFormat(item.content.start, item.content.length, contentFormat);
         for (const Span &marker : item.markers)
             setFormat(marker.start, marker.length, m_hiddenMarkerFormat);
@@ -202,7 +208,7 @@ void MarkdownHighlighter::highlightInline(const QString &text) {
 QList<MarkdownHighlighter::InlineMarkup> MarkdownHighlighter::inlineMarkup(const QString &text) {
     QList<InlineMarkup> markup;
     if (!text.contains(QLatin1Char('*')) && !text.contains(QLatin1Char('_'))
-            && !text.contains(QLatin1Char('['))) {
+            && !text.contains(QLatin1Char('[')) && !text.contains(QLatin1Char('~'))) {
         return markup;
     }
 
@@ -227,6 +233,14 @@ QList<MarkdownHighlighter::InlineMarkup> MarkdownHighlighter::inlineMarkup(const
         const int contentIndex = match.capturedStart(1) >= 0 ? 1 : 2;
         markup.append({InlineKind::Italic, span(match, contentIndex),
                        {{whole.start, 1}, {whole.start + whole.length - 1, 1}}});
+    }
+
+    static const QRegularExpression strikethroughRe(QStringLiteral("(~~)(.+?)(~~)"));
+    QRegularExpressionMatchIterator strikethroughMatches = strikethroughRe.globalMatch(text);
+    while (strikethroughMatches.hasNext()) {
+        const QRegularExpressionMatch match = strikethroughMatches.next();
+        markup.append({InlineKind::Strikethrough, span(match, 2),
+                       {span(match, 1), span(match, 3)}});
     }
 
     static const QRegularExpression linkRe(

--- a/src/markdownhighlighter.h
+++ b/src/markdownhighlighter.h
@@ -19,7 +19,7 @@ public:
         int length;
     };
 
-    enum class InlineKind { Bold, Italic, Link };
+    enum class InlineKind { Bold, Italic, Strikethrough, Link };
 
     struct InlineMarkup {
         InlineKind kind;
@@ -50,6 +50,7 @@ private:
     QTextCharFormat m_headingFormat;
     QTextCharFormat m_boldFormat;
     QTextCharFormat m_italicFormat;
+    QTextCharFormat m_strikethroughFormat;
     QTextCharFormat m_codeFormat;
     QTextCharFormat m_quoteFormat;
     QTextCharFormat m_linkFormat;

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -54,6 +54,17 @@ private slots:
         QCOMPARE(markup.at(2).markers[0].length, 1);
     }
 
+    void findsStrikethroughRanges() {
+        const auto markup =
+            MarkdownHighlighter::inlineMarkup(QStringLiteral("keep ~~drop this~~ keep"));
+        QCOMPARE(markup.size(), 1);
+        QCOMPARE(markup.at(0).kind, MarkdownHighlighter::InlineKind::Strikethrough);
+        QCOMPARE(markup.at(0).content.start, 7);
+        QCOMPARE(markup.at(0).content.length, 9);
+        QCOMPARE(markup.at(0).markers[0].length, 2);
+        QCOMPARE(markup.at(0).markers[1].length, 2);
+    }
+
     void loadsCurrentOmarchyTheme() {
         QTemporaryDir homeDirectory;
         QVERIFY(homeDirectory.isValid());
@@ -110,6 +121,57 @@ private slots:
         QCOMPARE(changedContents.write("changed elsewhere"), qint64(17));
         changedContents.close();
         QTRY_COMPARE(externalChangeSpy.count(), 1);
+    }
+
+    void togglesWrappedSelection() {
+        const QString mutationsPath = QFINDTESTDATA("../src/EditorMutations.js");
+        QVERIFY(!mutationsPath.isEmpty());
+
+        QQmlEngine engine;
+        QQmlComponent component(&engine);
+        const QByteArray harness = R"QML(
+            import QtQuick
+            import "EditorMutations.js" as EditorMutations
+
+            TextEdit {
+                property string wrappedText
+                property string unwrappedText
+                property int unwrappedSelectionStart
+                property int unwrappedSelectionEnd
+                property string emptyToggleText
+
+                Component.onCompleted: {
+                    text = "strike this";
+                    select(0, 6);
+                    EditorMutations.toggleWrap(this, "~~", "~~");
+                    wrappedText = text;
+                    EditorMutations.toggleWrap(this, "~~", "~~");
+                    unwrappedText = text;
+                    unwrappedSelectionStart = selectionStart;
+                    unwrappedSelectionEnd = selectionEnd;
+
+                    text = "";
+                    cursorPosition = 0;
+                    EditorMutations.toggleWrap(this, "~~", "~~");
+                    EditorMutations.toggleWrap(this, "~~", "~~");
+                    emptyToggleText = text;
+                }
+            }
+        )QML";
+        const QUrl harnessUrl = QUrl::fromLocalFile(
+            QFileInfo(mutationsPath).absolutePath() + QStringLiteral("/ToggleHarness.qml"));
+        component.setData(harness, harnessUrl);
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> editor(component.create());
+        QVERIFY2(editor, qPrintable(component.errorString()));
+
+        QCOMPARE(editor->property("wrappedText").toString(),
+                 QStringLiteral("~~strike~~ this"));
+        QCOMPARE(editor->property("unwrappedText").toString(),
+                 QStringLiteral("strike this"));
+        QCOMPARE(editor->property("unwrappedSelectionStart").toInt(), 0);
+        QCOMPARE(editor->property("unwrappedSelectionEnd").toInt(), 6);
+        QCOMPARE(editor->property("emptyToggleText").toString(), QString());
     }
 
     void keepsCursorAndSelectionStableAcrossInsertions() {

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -139,6 +139,8 @@ private slots:
                 property int unwrappedSelectionStart
                 property int unwrappedSelectionEnd
                 property string emptyToggleText
+                property string italicInsideBold
+                property string italicAroundBold
 
                 Component.onCompleted: {
                     text = "strike this";
@@ -155,6 +157,16 @@ private slots:
                     EditorMutations.toggleWrap(this, "~~", "~~");
                     EditorMutations.toggleWrap(this, "~~", "~~");
                     emptyToggleText = text;
+
+                    text = "**bold**";
+                    select(2, 6);
+                    EditorMutations.toggleWrap(this, "*", "*");
+                    italicInsideBold = text;
+
+                    text = "**bold**";
+                    select(0, 8);
+                    EditorMutations.toggleWrap(this, "*", "*");
+                    italicAroundBold = text;
                 }
             }
         )QML";
@@ -172,6 +184,10 @@ private slots:
         QCOMPARE(editor->property("unwrappedSelectionStart").toInt(), 0);
         QCOMPARE(editor->property("unwrappedSelectionEnd").toInt(), 6);
         QCOMPARE(editor->property("emptyToggleText").toString(), QString());
+        QCOMPARE(editor->property("italicInsideBold").toString(),
+                 QStringLiteral("***bold***"));
+        QCOMPARE(editor->property("italicAroundBold").toString(),
+                 QStringLiteral("***bold***"));
     }
 
     void keepsCursorAndSelectionStableAcrossInsertions() {


### PR DESCRIPTION
Adds a strikethrough shortcut alongside the existing bold/italic ones.

- `Ctrl+Shift+X` wraps the selection in `~~` markers (the shortcut Slack, VS Code, and Obsidian use).
- The highlighter renders `~~text~~` struck through and hides the markers exactly like `**` and `*`, so the caret skips over them too.
- The formatting shortcuts now toggle: pressing `Ctrl+B`, `Ctrl+I`, or `Ctrl+Shift+X` on already-wrapped text (or with the caret inside the markers) removes the markers instead of stacking another pair. The wrap/unwrap logic moved into `EditorMutations.js` so it's covered by the test harness.
- Shortcut added to the `Ctrl+?` reference and the README.

Two new tests (`findsStrikethroughRanges`, `togglesWrappedSelection`); all 14 pass.

![Strikethrough in Omawrite](https://raw.githubusercontent.com/joshualambert/omawrite/screenshots/strikethrough.png)
