### PR TITLE
Prevent editor clipping in narrow windows

### DIFF
--- a/src/Main.qml
+++ b/src/Main.qml
@@ -28,7 +28,7 @@ ApplicationWindow {
     readonly property int editorFontPixelSize: scaledSize(20)
     readonly property int editorWidth: Math.min(
         Math.round(writerFontMetrics.averageCharacterWidth * 65),
-        Math.max(360, width - Math.round(writerFontMetrics.averageCharacterWidth * 20)))
+        Math.max(0, width - 48))
     property bool closeConfirmed: false
     property bool searchOpen: false
     property bool searchUpdating: false

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -26,8 +26,11 @@ ApplicationWindow {
     // the app at the sizes it was designed around.
     readonly property real textScale: backend.textScale
     readonly property int editorFontPixelSize: scaledSize(20)
+    // Never wider than the Flickable's viewport, whatever the floor asks for:
+    // a tiling compositor can resize the window below its minimum width.
     readonly property int editorWidth: Math.min(
         Math.round(writerFontMetrics.averageCharacterWidth * 65),
+        Math.max(360, width - Math.round(writerFontMetrics.averageCharacterWidth * 20)),
         Math.max(0, width - 48))
     property bool closeConfirmed: false
     property bool searchOpen: false

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -218,6 +218,40 @@ private slots:
         QCOMPARE(editor->property("font").value<QFont>().pixelSize(), 15);
     }
 
+    void keepsTextColumnInsideNarrowWindows() {
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        Backend backend;
+        QQmlEngine engine;
+        engine.rootContext()->setContextProperty(QStringLiteral("backend"), &backend);
+        QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> window(component.create());
+        QVERIFY2(window, qPrintable(component.errorString()));
+
+        QObject *editor = window->findChild<QObject *>(QStringLiteral("sourceEditor"));
+        QVERIFY(editor);
+        QObject *viewport = editor->parent();
+        QVERIFY(viewport);
+
+        // A resize reaches the window through its platform window, so the
+        // bindings only see the new width once the events are delivered.
+        const int minimumWidth = window->property("minimumWidth").toInt();
+        window->setProperty("width", minimumWidth);
+        QCoreApplication::processEvents();
+        QCOMPARE(window->property("width").toInt(), minimumWidth);
+        QVERIFY(editor->property("x").toInt() > 0);
+
+        // A tiling compositor resizes below the minimum the window asks for.
+        window->setProperty("width", 394);
+        QCoreApplication::processEvents();
+        QCOMPARE(window->property("width").toInt(), 394);
+        QVERIFY(editor->property("width").toInt()
+                <= viewport->property("width").toInt());
+        QVERIFY(editor->property("x").toInt() >= 0);
+    }
+
     void remembersLastSaveDirectory() {
         QTemporaryDir saveDirectory;
         QVERIFY(saveDirectory.isValid());


### PR DESCRIPTION
## Summary

Allow the editor to shrink to the space available inside its existing 24 px side margins.

Hyprland can resize Omawrite below its declared minimum window width. Below 408 px, the previous 360 px editor floor exceeded the viewport and clipped text on both sides.

This preserves the existing margins and 65-character maximum width at normal window sizes. It only changes behavior when the window is too narrow for the previous minimum.

## Validation

- Manually tested in a 394 px-wide tiled window
- Confirmed the text remains visible and wraps without clipping
- Confirmed normal margins and wide-window layout are unchanged
- `./bin/test` — 13 passed with Qt 6.11.2 on Omarchy 4.0.0
- `./bin/build`
- `git diff --check`

## Local test-build note

A test binary installed under the alternate name `omawrite-custom` gives its native open/save dialog the `omawrite-custom` window class. A local Hyprland rule that matched only `omawrite` therefore missed that dialog and allowed Qt's oversized dialog surface to cover the workspace. Expanding the local matcher fixed the test setup. This does not require a source change here because the packaged target and desktop entry remain `omawrite`.
