### PR TITLE
Let the editor fill the window, with a configurable measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Omawrite at the size it is designed around; larger and smaller sizes scale from 
 
 ## Requirements
 
-- Qt 6: `qt6-base`, `qt6-declarative`, `qt6-quickcontrols2`
+- Qt 6.5 or newer: `qt6-base`, `qt6-declarative`, `qt6-quickcontrols2`
 - `xdg-desktop-portal` and a portal backend
 
 The iA Writer Mono font is bundled under the SIL Open Font License 1.1; see

--- a/omawrite.pro
+++ b/omawrite.pro
@@ -1,3 +1,5 @@
+!versionAtLeast(QT_VERSION, 6.5.0): error("Omawrite requires Qt 6.5 or newer (the QtCore Settings QML type)")
+
 QT += core gui widgets printsupport qml quick quickcontrols2 quickdialogs2 dbus
 
 CONFIG += c++17 release

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -8,8 +8,8 @@ arch=('x86_64')
 url='https://github.com/omacom-io/omawrite'
 license=('MIT')
 install='omawrite.install'
-depends=('qt6-base' 'qt6-declarative' 'xdg-desktop-portal')
-makedepends=('gcc' 'make' 'qt6-base' 'qt6-declarative')
+depends=('qt6-base>=6.5' 'qt6-declarative>=6.5' 'xdg-desktop-portal')
+makedepends=('gcc' 'make' 'qt6-base>=6.5' 'qt6-declarative>=6.5')
 source=()
 sha256sums=()
 

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -1,3 +1,4 @@
+import QtCore
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.Material
@@ -26,9 +27,13 @@ ApplicationWindow {
     // the app at the sizes it was designed around.
     readonly property real textScale: backend.textScale
     readonly property int editorFontPixelSize: scaledSize(20)
-    readonly property int editorWidth: Math.min(
-        Math.round(writerFontMetrics.averageCharacterWidth * 65),
-        Math.max(360, width - Math.round(writerFontMetrics.averageCharacterWidth * 20)))
+    readonly property int availableEditorWidth:
+        Math.max(360, width - Math.round(writerFontMetrics.averageCharacterWidth * 20))
+    readonly property int editorWidth: layoutSettings.editorColumns > 0
+        ? Math.min(
+              Math.round(writerFontMetrics.averageCharacterWidth * Math.max(20, layoutSettings.editorColumns)),
+              availableEditorWidth)
+        : availableEditorWidth
     property bool closeConfirmed: false
     property bool searchOpen: false
     property bool searchUpdating: false
@@ -42,6 +47,15 @@ ApplicationWindow {
     Material.theme: darkMode ? Material.Dark : Material.Light
     Material.accent: backend.themeAccent
     color: pageColor
+
+    // Editor measure in average character widths. 0 (the default) lets the
+    // text fill the window, keeping ten characters of margin on either side;
+    // a positive value gives a fixed measure — 65 is the app's classic look.
+    Settings {
+        id: layoutSettings
+        category: "layout"
+        property int editorColumns: 0
+    }
 
     onClosing: function(close) {
         if (closeConfirmed || !backend.modified)


### PR DESCRIPTION
The editor measure is hardcoded at 65 average character widths. That is a classic default for prose, but on a large display most of the window is empty margin, and notes with long list items (meeting minutes, task lists) wrap early. It also caps information density: combined with text-size shortcuts (#25), shrinking the font just shrinks the column — you never fit more text per line.

This lets the text use the window instead:

- By default the editor fills the available width, keeping the existing ten characters of margin on either side (the `width - 20ch` term that already existed).
- The classic fixed measure stays available via the existing QSettings store: `[layout] editorColumns` in `omawrite.conf` — `0` (default) fills the window; a positive value gives a fixed measure (clamped ≥20, still capped by window width); `65` restores today's look exactly. No new UI.

To be upfront: this changes the default look — the column is wider on large windows. If you'd rather keep 65 as the default, the same patch works with the default flipped; happy to adjust.

Tested on Omarchy (Qt 6.11) in both modes, including the interplay with #25 (smaller font → more characters per line when filling the window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5cK4VRT6nuLGuwEJrZvRD