### PR TITLE
Add Ctrl+= / Ctrl+- / Ctrl+0 text size shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Omawrite at the size it is designed around; larger and smaller sizes scale from 
 
 ## Requirements
 
-- Qt 6: `qt6-base`, `qt6-declarative`, `qt6-quickcontrols2`
+- Qt 6.5 or newer: `qt6-base`, `qt6-declarative`, `qt6-quickcontrols2`
 - `xdg-desktop-portal` and a portal backend
 
 The iA Writer Mono font is bundled under the SIL Open Font License 1.1; see

--- a/omawrite.pro
+++ b/omawrite.pro
@@ -1,3 +1,5 @@
+!versionAtLeast(QT_VERSION, 6.5.0): error("Omawrite requires Qt 6.5 or newer (the QtCore Settings QML type)")
+
 QT += core gui widgets printsupport qml quick quickcontrols2 quickdialogs2 dbus
 
 CONFIG += c++17 release

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -8,8 +8,8 @@ arch=('x86_64')
 url='https://github.com/omacom-io/omawrite'
 license=('MIT')
 install='omawrite.install'
-depends=('qt6-base' 'qt6-declarative' 'xdg-desktop-portal')
-makedepends=('gcc' 'make' 'qt6-base' 'qt6-declarative')
+depends=('qt6-base>=6.5' 'qt6-declarative>=6.5' 'xdg-desktop-portal')
+makedepends=('gcc' 'make' 'qt6-base>=6.5' 'qt6-declarative>=6.5')
 source=()
 sha256sums=()
 

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -1,3 +1,4 @@
+import QtCore
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.Material
@@ -25,7 +26,7 @@ ApplicationWindow {
     // `omarchy display text size` drives) anchored so its 12px default leaves
     // the app at the sizes it was designed around.
     readonly property real textScale: backend.textScale
-    readonly property int editorFontPixelSize: scaledSize(20)
+    readonly property int editorFontPixelSize: scaledSize(Math.max(8, Math.min(72, fontSettings.editorFontSize)))
     readonly property int editorWidth: Math.min(
         Math.round(writerFontMetrics.averageCharacterWidth * 65),
         Math.max(360, width - Math.round(writerFontMetrics.averageCharacterWidth * 20)))
@@ -42,6 +43,14 @@ ApplicationWindow {
     Material.theme: darkMode ? Material.Dark : Material.Light
     Material.accent: backend.themeAccent
     color: pageColor
+
+    // Editor font size in pixels (before text scaling), adjustable with
+    // Ctrl+=/Ctrl+- and reset with Ctrl+0; persisted across sessions.
+    Settings {
+        id: fontSettings
+        category: "layout"
+        property int editorFontSize: 20
+    }
 
     onClosing: function(close) {
         if (closeConfirmed || !backend.modified)
@@ -209,6 +218,24 @@ ApplicationWindow {
     }
 
     Shortcut {
+        sequences: ["Ctrl+=", "Ctrl++"]
+        context: Qt.ApplicationShortcut
+        onActivated: fontSettings.editorFontSize = Math.min(72, fontSettings.editorFontSize + 1)
+    }
+
+    Shortcut {
+        sequence: "Ctrl+-"
+        context: Qt.ApplicationShortcut
+        onActivated: fontSettings.editorFontSize = Math.max(8, fontSettings.editorFontSize - 1)
+    }
+
+    Shortcut {
+        sequence: "Ctrl+0"
+        context: Qt.ApplicationShortcut
+        onActivated: fontSettings.editorFontSize = 20
+    }
+
+    Shortcut {
         sequence: "Ctrl+Z"
         context: Qt.WindowShortcut
         onActivated: editor.undo()
@@ -331,7 +358,7 @@ ApplicationWindow {
         standardButtons: Dialog.Close
         anchors.centerIn: parent
         contentItem: Label {
-            text: "Ctrl+S  Save\nCtrl+Shift+S  Save As\nCtrl+O  Open\nCtrl+N  New Window\nCtrl+F  Find\nCtrl+H  Find and Replace\nCtrl+B  Bold\nCtrl+I  Italic\nCtrl+K  Link\nCtrl+P  Print\nF11 / Super+F  Fullscreen\nCtrl+?  Shortcuts"
+            text: "Ctrl+S  Save\nCtrl+Shift+S  Save As\nCtrl+O  Open\nCtrl+N  New Window\nCtrl+F  Find\nCtrl+H  Find and Replace\nCtrl+B  Bold\nCtrl+I  Italic\nCtrl+K  Link\nCtrl+P  Print\nCtrl+= / Ctrl+-  Text Size\nCtrl+0  Reset Text Size\nF11 / Super+F  Fullscreen\nCtrl+?  Shortcuts"
             lineHeight: 1.5
         }
     }


### PR DESCRIPTION
Browsers and terminals train the same reflex everywhere: Ctrl+= to grow the text, Ctrl+- to shrink it, Ctrl+0 to reset. Omawrite's editor size is fixed at 20px, so the only recourse today is the desktop-wide text scaling knob, which drags every other app along.

This wires that reflex up:

- Ctrl+= / Ctrl++ grows, Ctrl+- shrinks, Ctrl+0 resets to the current 20px default (clamped 8–72px).
- The size persists across sessions via the existing QSettings store (`[layout] editorFontSize`) — no new UI.
- The desktop text scale still multiplies on top exactly as before.
- The shortcuts are listed in the Ctrl+? dialog.

On current master the measure is a fixed 65 characters, so zooming changes glyph size at constant characters per line. Paired with #24 (editor fills the window by default), Ctrl+- also packs more characters per line, matching what the same shortcut does in a terminal. The PRs are independent; if both land, the two `Settings` blocks merge trivially.

Tested on Omarchy (Qt 6.11) with all three shortcuts, including persistence across restarts and the combination with #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5cK4VRT6nuLGuwEJrZvRD