### PR TITLE
Read theme colors past an inline TOML comment

### DIFF
--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -573,15 +573,28 @@ void Backend::watchCurrentFile() {
         m_fileWatcher.addPath(m_fileUrl.toLocalFile());
 }
 
-void Backend::loadOmarchyTheme() {
-    m_themeBackground = m_darkMode ? QStringLiteral("#101010") : QStringLiteral("#ffffff");
-    m_themeForeground = m_darkMode ? QStringLiteral("#eeeeee") : QStringLiteral("#222324");
-    m_themeAccent = m_darkMode ? QStringLiteral("#5584aa") : QStringLiteral("#2077b2");
-    m_themeSelection = m_darkMode ? QStringLiteral("#186a9a") : QStringLiteral("#2077b2");
+// A quoted TOML value ends at its closing quote; whatever trails it is an inline comment.
+QString Backend::tomlValue(const QString &text) {
+    const QString value = text.trimmed();
+    if (value.isEmpty())
+        return value;
 
+    const QChar quote = value.front();
+    if (quote != QLatin1Char('"') && quote != QLatin1Char('\''))
+        return value;
+
+    const int close = value.indexOf(quote, 1);
+    return close < 0 ? value : value.mid(1, close - 1);
+}
+
+void Backend::loadOmarchyTheme() {
     const QString colorsPath = QDir::homePath()
         + QStringLiteral("/.local/state/omarchy/current/theme/colors.toml");
     QString themeMode;
+    QString background;
+    QString foreground;
+    QString accent;
+    QString selection;
     QFile file(colorsPath);
     if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         QTextStream in(&file);
@@ -595,52 +608,61 @@ void Backend::loadOmarchyTheme() {
                 continue;
 
             const QString key = line.left(equals).trimmed();
-            QString value = line.mid(equals + 1).trimmed();
-            if (value.size() >= 2
-                    && ((value.front() == QLatin1Char('"') && value.back() == QLatin1Char('"'))
-                        || (value.front() == QLatin1Char('\'') && value.back() == QLatin1Char('\''))))
-                value = value.mid(1, value.size() - 2);
+            const QString value = tomlValue(line.mid(equals + 1));
 
             if (key == QStringLiteral("mode"))
                 themeMode = value;
             else if (key == QStringLiteral("background"))
-                m_themeBackground = value;
+                background = value;
             else if (key == QStringLiteral("foreground"))
-                m_themeForeground = value;
+                foreground = value;
             else if (key == QStringLiteral("accent"))
-                m_themeAccent = value;
+                accent = value;
             else if (key == QStringLiteral("selection"))
-                m_themeSelection = value;
+                selection = value;
         }
     }
 
-    bool themeModeKnown = false;
     bool themeIsDark = m_darkMode;
     if (themeMode == QStringLiteral("dark")) {
         themeIsDark = true;
-        themeModeKnown = true;
     } else if (themeMode == QStringLiteral("light")) {
         themeIsDark = false;
-        themeModeKnown = true;
     } else {
-        const QColor background(m_themeBackground);
-        if (background.isValid()) {
-            const double luminance = 0.299 * background.redF()
-                + 0.587 * background.greenF() + 0.114 * background.blueF();
+        const QColor parsedBackground(background);
+        if (parsedBackground.isValid()) {
+            const double luminance = 0.299 * parsedBackground.redF()
+                + 0.587 * parsedBackground.greenF() + 0.114 * parsedBackground.blueF();
             themeIsDark = luminance < 0.5;
-            themeModeKnown = true;
         }
     }
-    if (themeModeKnown && themeIsDark != m_darkMode) {
-        m_darkMode = themeIsDark;
-        emit darkModeChanged();
-    }
+    const bool darkModeFlipped = themeIsDark != m_darkMode;
+    m_darkMode = themeIsDark;
+
+    // The defaults follow the mode the theme resolved to, so a colour we cannot
+    // read costs that one colour rather than the contrast of the whole editor.
+    m_themeBackground = m_darkMode ? QStringLiteral("#101010") : QStringLiteral("#ffffff");
+    m_themeForeground = m_darkMode ? QStringLiteral("#eeeeee") : QStringLiteral("#222324");
+    m_themeAccent = m_darkMode ? QStringLiteral("#5584aa") : QStringLiteral("#2077b2");
+    m_themeSelection = m_darkMode ? QStringLiteral("#186a9a") : QStringLiteral("#2077b2");
+
+    // An unparseable colour reaches QML as black, so keep the default instead.
+    const auto applyColor = [](QString &target, const QString &value) {
+        if (QColor(value).isValid())
+            target = value;
+    };
+    applyColor(m_themeBackground, background);
+    applyColor(m_themeForeground, foreground);
+    applyColor(m_themeAccent, accent);
+    applyColor(m_themeSelection, selection);
 
     if (m_highlighter) {
         m_highlighter->setDarkMode(m_darkMode);
         m_highlighter->setColors(m_themeBackground, m_themeForeground, m_themeAccent);
     }
 
+    if (darkModeFlipped)
+        emit darkModeChanged();
     emit themeColorsChanged();
 }
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -52,6 +52,7 @@ public:
     static int countWords(const QString &text);
     static QString normalizedLinkUrl(const QString &clipboardText);
     static QString suggestedFileName(const QString &text);
+    static QString tomlValue(const QString &text);
 
     Q_INVOKABLE void attachDocument(QObject *textDocument);
     Q_INVOKABLE void openDialog();

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -55,30 +55,13 @@ private slots:
     }
 
     void loadsCurrentOmarchyTheme() {
-        QTemporaryDir homeDirectory;
-        QVERIFY(homeDirectory.isValid());
-
-        const QByteArray originalHome = qgetenv("HOME");
-        struct HomeRestorer {
-            QByteArray value;
-            ~HomeRestorer() { qputenv("HOME", value); }
-        } restoreHome{originalHome};
-        QVERIFY(qputenv("HOME", homeDirectory.path().toUtf8()));
-
-        const QString themeDirectory = homeDirectory.path()
-            + QStringLiteral("/.local/state/omarchy/current/theme");
-        QVERIFY(QDir().mkpath(themeDirectory));
-
-        QFile colorsFile(themeDirectory + QStringLiteral("/colors.toml"));
-        QVERIFY(colorsFile.open(QIODevice::WriteOnly | QIODevice::Text));
-        const QByteArray palette(
+        ScopedTheme theme(
             "mode = \"light\"\n"
             "accent = \"#112233\"\n"
             "selection = \"#445566\"\n"
             "background = \"#fefefe\"\n"
             "foreground = \"#101010\"\n");
-        QCOMPARE(colorsFile.write(palette), qint64(palette.size()));
-        colorsFile.close();
+        QVERIFY(theme.ok);
 
         Backend backend;
         QCOMPARE(backend.themeBackground(), QStringLiteral("#fefefe"));
@@ -86,6 +69,50 @@ private slots:
         QCOMPARE(backend.themeAccent(), QStringLiteral("#112233"));
         QCOMPARE(backend.themeSelection(), QStringLiteral("#445566"));
         QVERIFY(!backend.darkMode());
+    }
+
+    void readsTomlValuesPastInlineComments() {
+        // Every colour in every theme is a quoted "#rrggbb": the hash inside the quotes stays.
+        QCOMPARE(Backend::tomlValue(QStringLiteral(" \"#1a1b26\" ")), QStringLiteral("#1a1b26"));
+        QCOMPARE(Backend::tomlValue(QStringLiteral("\"#EDE6D6\"   # unbleached cloth")),
+                 QStringLiteral("#EDE6D6"));
+        QCOMPARE(Backend::tomlValue(QStringLiteral("'#445566'# no space before the hash")),
+                 QStringLiteral("#445566"));
+        QCOMPARE(Backend::tomlValue(QStringLiteral("\"rebecca#purple\"")),
+                 QStringLiteral("rebecca#purple"));
+        QCOMPARE(Backend::tomlValue(QStringLiteral(" #1a1b26 ")), QStringLiteral("#1a1b26"));
+        QCOMPARE(Backend::tomlValue(QStringLiteral("\"#1a1b26")), QStringLiteral("\"#1a1b26"));
+        QCOMPARE(Backend::tomlValue(QStringLiteral("\"\"")), QString());
+        QCOMPARE(Backend::tomlValue(QString()), QString());
+    }
+
+    void keepsDefaultsForColorsItCannotParse() {
+        ScopedTheme theme(
+            "mode = \"dark\"          # warmed ink\r\n"
+            "accent = \"#112233\"     # shell-white pigment\r\n"
+            "selection = '#445566'\r\n"
+            "background = \"#1a1b17\" # ink, warmed\r\n"
+            "foreground = \"unbleached cloth\"\r\n");
+        QVERIFY(theme.ok);
+
+        Backend backend;
+        QCOMPARE(backend.themeBackground(), QStringLiteral("#1a1b17"));
+        QCOMPARE(backend.themeAccent(), QStringLiteral("#112233"));
+        QCOMPARE(backend.themeSelection(), QStringLiteral("#445566"));
+        QCOMPARE(backend.themeForeground(), QStringLiteral("#eeeeee"));
+        QVERIFY(backend.darkMode());
+    }
+
+    void takesItsDefaultsFromTheModeTheThemeAsksFor() {
+        ScopedTheme theme(
+            "mode = \"light\"\n"
+            "background = \"#ffffff\"\n"
+            "foreground = \"unbleached cloth\"\n");
+        QVERIFY(theme.ok);
+
+        Backend backend;
+        QVERIFY(!backend.darkMode());
+        QCOMPARE(backend.themeForeground(), QStringLiteral("#222324"));
     }
 
     void ignoresFileWatcherEventsForSavedContents() {
@@ -247,6 +274,24 @@ private slots:
     }
 
 private:
+    // Points HOME at a scratch tree holding one colors.toml, and puts it back on the way out.
+    struct ScopedTheme {
+        explicit ScopedTheme(const QByteArray &palette) {
+            const QString themeDirectory = home.path()
+                + QStringLiteral("/.local/state/omarchy/current/theme");
+            QFile colorsFile(themeDirectory + QStringLiteral("/colors.toml"));
+            ok = home.isValid() && QDir().mkpath(themeDirectory)
+                && qputenv("HOME", home.path().toUtf8())
+                && colorsFile.open(QIODevice::WriteOnly | QIODevice::Text)
+                && colorsFile.write(palette) == qint64(palette.size());
+        }
+        ~ScopedTheme() { qputenv("HOME", originalHome); }
+
+        QTemporaryDir home;
+        QByteArray originalHome = qgetenv("HOME");
+        bool ok = false;
+    };
+
     QTemporaryDir m_settingsDirectory;
 };
 


### PR DESCRIPTION
`Backend::loadOmarchyTheme()` took everything after the first `=` as the value and unwrapped it only when it began and ended with a quote. An inline comment leaves the value ending in the comment text rather than a quote, so `foreground = "#EDE6D6"        # unbleached cloth` reached QML as the literal string `"#EDE6D6"        # unbleached cloth`. QML coerces a color it cannot parse to opaque black, and `MarkdownHighlighter` builds an equally invalid `QColor` from the same string, so a theme that annotates its palette — which TOML allows, and which Omarchy's own `bin/omarchy-theme-color` handles — rendered the editor black on black.

A quoted value now ends at its closing quote, and whatever trails it is dropped. Unquoted values stay verbatim, which is what `omarchy-theme-color` does too, so a theme writing `background = #1a1b26` still works. Truncating the value at its first hash instead would empty every color in every shipped theme, since all of them are quoted hex.

A color `QColor` cannot read now leaves the built-in default in place instead of reaching the window as black, and the defaults are chosen after the theme's mode is resolved rather than before. Resolving them first would answer a light theme carrying one malformed color with the dark default painted onto a white page.

Fixes #32