### PR TITLE
Add persistent editor font size controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Install via the Omarchy Package Repository via the `omawrite` package. It's inst
 - `Ctrl+F` searches the document. Use `Enter` or `Ctrl+G` for the next match and `Shift+Enter` for the previous match.
 - `Ctrl+H` opens find and replace.
 - `Ctrl+B`, `Ctrl+I`, and `Ctrl+K` insert bold, italic, and link Markdown.
+- `Ctrl++` and `Ctrl+-` adjust the editor text size. `Ctrl+=` also increases it,
+  and `Ctrl+0` resets it to the original size.
 - `Ctrl+?` shows the keyboard shortcut reference.
 
 Unsaved drafts are recovered after an abnormal exit. Omawrite also watches open files
@@ -30,6 +32,8 @@ and warns before an external change can replace local work.
 Text follows the desktop text size — `omarchy display text size`, or GNOME's
 `text-scaling-factor` — and re-flows without a restart. The default of 12px leaves
 Omawrite at the size it is designed around; larger and smaller sizes scale from there.
+Editor text size starts at 20px, changes in 2px steps from 10px to 48px, and is
+remembered across launches. Desktop text scaling is applied on top of this base size.
 
 ## Requirements
 

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -25,7 +25,7 @@ ApplicationWindow {
     // `omarchy display text size` drives) anchored so its 12px default leaves
     // the app at the sizes it was designed around.
     readonly property real textScale: backend.textScale
-    readonly property int editorFontPixelSize: scaledSize(20)
+    readonly property int editorFontPixelSize: scaledSize(backend.editorFontSize)
     readonly property int editorWidth: Math.min(
         Math.round(writerFontMetrics.averageCharacterWidth * 65),
         Math.max(360, width - Math.round(writerFontMetrics.averageCharacterWidth * 20)))
@@ -152,6 +152,24 @@ ApplicationWindow {
             searchField.forceActiveFocus();
             searchField.selectAll();
         }
+    }
+
+    Shortcut {
+        sequences: ["Ctrl++", "Ctrl+="]
+        context: Qt.ApplicationShortcut
+        onActivated: backend.editorFontSize += 2
+    }
+
+    Shortcut {
+        sequence: "Ctrl+-"
+        context: Qt.ApplicationShortcut
+        onActivated: backend.editorFontSize -= 2
+    }
+
+    Shortcut {
+        sequence: "Ctrl+0"
+        context: Qt.ApplicationShortcut
+        onActivated: backend.resetEditorFontSize()
     }
 
     Shortcut {
@@ -331,7 +349,7 @@ ApplicationWindow {
         standardButtons: Dialog.Close
         anchors.centerIn: parent
         contentItem: Label {
-            text: "Ctrl+S  Save\nCtrl+Shift+S  Save As\nCtrl+O  Open\nCtrl+N  New Window\nCtrl+F  Find\nCtrl+H  Find and Replace\nCtrl+B  Bold\nCtrl+I  Italic\nCtrl+K  Link\nCtrl+P  Print\nF11 / Super+F  Fullscreen\nCtrl+?  Shortcuts"
+            text: "Ctrl+S  Save\nCtrl+Shift+S  Save As\nCtrl+O  Open\nCtrl+N  New Window\nCtrl+F  Find\nCtrl+H  Find and Replace\nCtrl+B  Bold\nCtrl+I  Italic\nCtrl+K  Link\nCtrl++ / Ctrl+=  Increase text size\nCtrl+-  Decrease text size\nCtrl+0  Reset text size\nCtrl+P  Print\nF11 / Super+F  Fullscreen\nCtrl+?  Shortcuts"
             lineHeight: 1.5
         }
     }

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -35,6 +35,10 @@
 
 constexpr qreal typoraLineHeightPercent = 140;
 const QString lastSaveDirectorySetting = QStringLiteral("file/lastSaveDirectory");
+const QString editorFontSizeSetting = QStringLiteral("editor/fontSize");
+constexpr int defaultEditorFontSize = 20;
+constexpr int minimumEditorFontSize = 10;
+constexpr int maximumEditorFontSize = 48;
 
 QString Backend::normalizedLinkUrl(const QString &clipboardText) {
     QString candidate = clipboardText.trimmed();
@@ -72,6 +76,11 @@ QString Backend::normalizedLinkUrl(const QString &clipboardText) {
 }
 
 Backend::Backend(QObject *parent) : QObject(parent) {
+    m_editorFontSize = qBound(minimumEditorFontSize,
+                              QSettings().value(editorFontSizeSetting,
+                                                defaultEditorFontSize).toInt(),
+                              maximumEditorFontSize);
+
     const QString stateDirectory = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     QDir().mkpath(stateDirectory);
     // Claim an orphaned snapshot before taking an empty slot. This ensures a
@@ -164,6 +173,21 @@ void Backend::setTextScale(qreal textScale) {
 
     m_textScale = textScale;
     emit textScaleChanged();
+}
+
+void Backend::setEditorFontSize(int editorFontSize) {
+    const int boundedSize = qBound(minimumEditorFontSize, editorFontSize,
+                                   maximumEditorFontSize);
+    if (m_editorFontSize == boundedSize)
+        return;
+
+    m_editorFontSize = boundedSize;
+    QSettings().setValue(editorFontSizeSetting, m_editorFontSize);
+    emit editorFontSizeChanged();
+}
+
+void Backend::resetEditorFontSize() {
+    setEditorFontSize(defaultEditorFontSize);
 }
 
 void Backend::attachDocument(QObject *textDocument) {

--- a/src/backend.h
+++ b/src/backend.h
@@ -24,6 +24,8 @@ class Backend : public QObject {
     Q_PROPERTY(int wordCount READ wordCount NOTIFY wordCountChanged)
     Q_PROPERTY(bool darkMode READ darkMode WRITE setDarkMode NOTIFY darkModeChanged)
     Q_PROPERTY(qreal textScale READ textScale WRITE setTextScale NOTIFY textScaleChanged)
+    Q_PROPERTY(int editorFontSize READ editorFontSize WRITE setEditorFontSize
+               NOTIFY editorFontSizeChanged)
     Q_PROPERTY(QString themeBackground READ themeBackground NOTIFY themeColorsChanged)
     Q_PROPERTY(QString themeForeground READ themeForeground NOTIFY themeColorsChanged)
     Q_PROPERTY(QString themeAccent READ themeAccent NOTIFY themeColorsChanged)
@@ -45,6 +47,8 @@ public:
     void setDarkMode(bool darkMode);
     qreal textScale() const { return m_textScale; }
     void setTextScale(qreal textScale);
+    int editorFontSize() const { return m_editorFontSize; }
+    void setEditorFontSize(int editorFontSize);
     QString themeBackground() const { return m_themeBackground; }
     QString themeForeground() const { return m_themeForeground; }
     QString themeAccent() const { return m_themeAccent; }
@@ -64,6 +68,7 @@ public:
     Q_INVOKABLE void discardRecovery();
     Q_INVOKABLE void reloadFromDisk();
     Q_INVOKABLE void keepExternalVersion();
+    Q_INVOKABLE void resetEditorFontSize();
     Q_INVOKABLE void printDocument();
     Q_INVOKABLE void newWindow();
     Q_INVOKABLE QString clipboardUrl() const;
@@ -82,6 +87,7 @@ signals:
     void wordCountChanged();
     void darkModeChanged();
     void textScaleChanged();
+    void editorFontSizeChanged();
     void themeColorsChanged();
     void closeAfterSave();
     void openDialogRequested();
@@ -117,6 +123,7 @@ private:
     int m_wordCount = 0;
     bool m_darkMode = true;
     qreal m_textScale = 1.0;
+    int m_editorFontSize = 20;
     bool m_loading = false;
     bool m_closeAfterSave = false;
     bool m_formattingTypography = false;

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -3,6 +3,7 @@
 #include <QQmlComponent>
 #include <QQmlContext>
 #include <QQmlEngine>
+#include <QQuickWindow>
 #include <QQuickStyle>
 
 #include "backend.h"
@@ -18,6 +19,10 @@ private slots:
         QSettings::setDefaultFormat(QSettings::IniFormat);
         QSettings::setPath(QSettings::IniFormat, QSettings::UserScope,
                            m_settingsDirectory.path());
+    }
+
+    void init() {
+        QSettings().clear();
     }
 
     void countsWords() {
@@ -216,6 +221,55 @@ private slots:
         backend.setTextScale(9.0 / 12.0);
         QCOMPARE(window->property("editorFontPixelSize").toInt(), 15);
         QCOMPARE(editor->property("font").value<QFont>().pixelSize(), 15);
+    }
+
+    void dispatchesEditorFontSizeShortcuts() {
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        Backend backend;
+        QQmlEngine engine;
+        engine.rootContext()->setContextProperty(QStringLiteral("backend"), &backend);
+        QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> root(component.create());
+        QVERIFY2(root, qPrintable(component.errorString()));
+
+        auto *window = qobject_cast<QQuickWindow *>(root.data());
+        QVERIFY(window);
+        window->requestActivate();
+        QTRY_VERIFY(window->isActive());
+
+        QCOMPARE(backend.editorFontSize(), 20);
+        QTest::keyClick(window, Qt::Key_Equal, Qt::ControlModifier);
+        QCOMPARE(backend.editorFontSize(), 22);
+        QTest::keyClick(window, Qt::Key_Plus, Qt::ControlModifier);
+        QCOMPARE(backend.editorFontSize(), 24);
+        QTest::keyClick(window, Qt::Key_Minus, Qt::ControlModifier);
+        QCOMPARE(backend.editorFontSize(), 22);
+        QTest::keyClick(window, Qt::Key_0, Qt::ControlModifier);
+        QCOMPARE(backend.editorFontSize(), 20);
+        QCOMPARE(QSettings().value(QStringLiteral("editor/fontSize")).toInt(), 20);
+    }
+
+    void persistsEditorFontSizeAcrossBackendInstances() {
+        {
+            Backend backend;
+            QCOMPARE(backend.editorFontSize(), 20);
+
+            QSignalSpy changedSpy(&backend, &Backend::editorFontSizeChanged);
+            backend.setEditorFontSize(28);
+            QCOMPARE(changedSpy.count(), 1);
+            QCOMPARE(QSettings().value(QStringLiteral("editor/fontSize")).toInt(), 28);
+        }
+
+        Backend restoredBackend;
+        QCOMPARE(restoredBackend.editorFontSize(), 28);
+
+        restoredBackend.setEditorFontSize(100);
+        QCOMPARE(restoredBackend.editorFontSize(), 48);
+        restoredBackend.setEditorFontSize(0);
+        QCOMPARE(restoredBackend.editorFontSize(), 10);
     }
 
     void remembersLastSaveDirectory() {


### PR DESCRIPTION
Omawrite follows desktop text scaling, but it does not provide a way to adjust the editor text independently. This adds `Ctrl++` and `Ctrl+=` to increase the editor font size, `Ctrl+-` to decrease it, and `Ctrl+0` to restore the shipped 20px size. Adjustments use 2px steps and remain within 10–48px.

Backend owns the unscaled base size through a Q_PROPERTY and persists it under `editor/fontSize`. QML continues to apply the existing Omarchy and GNOME desktop text scaling on top of that base size.

The keyboard shortcut dialog and README document the controls.
