### PR TITLE
Keep editor content out of the footer

### DIFF
--- a/src/Main.qml
+++ b/src/Main.qml
@@ -341,7 +341,11 @@ ApplicationWindow {
 
         Flickable {
             id: editorFlick
-            anchors.fill: parent
+            objectName: "editorViewport"
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: footer.top
             anchors.leftMargin: 24
             anchors.rightMargin: 24
             clip: true
@@ -354,12 +358,6 @@ ApplicationWindow {
                 // flicking the Flickable, so the bar has to be told about
                 // that activity; linger briefly after the last event.
                 active: hovered || pressed || wheelScroll.running || scrollLinger.running
-                // Stop above the footer strip so the bar doesn't overlap
-                // the word count in the bottom-right corner. Padding and
-                // inset, not anchors: the attached-ScrollBar layout overrides
-                // anchors. Padding stops the thumb, the inset the track.
-                bottomPadding: win.scaledSize(32)
-                bottomInset: win.scaledSize(32)
             }
 
             Timer {
@@ -796,56 +794,65 @@ ApplicationWindow {
             }
         }
 
-        Row {
-            id: footerStatus
+        Rectangle {
+            id: footer
+            objectName: "footer"
             anchors.left: parent.left
+            anchors.right: parent.right
             anchors.bottom: parent.bottom
-            anchors.leftMargin: 12
-            anchors.bottomMargin: 10
-            spacing: 12
-            opacity: 0.55
+            height: Math.max(36, win.scaledSize(36))
+            color: win.pageColor
 
-            FooterIconButton {
-                objectName: "saveButton"
-                iconName: "save"
-                iconColor: win.mutedColor
-                tooltip: "Save"
-                onClicked: backend.save()
-            }
+            Row {
+                id: footerStatus
+                anchors.left: parent.left
+                anchors.bottom: parent.bottom
+                anchors.leftMargin: 12
+                anchors.bottomMargin: 10
+                spacing: 12
+                opacity: 0.55
 
-            FooterIconButton {
-                objectName: "openButton"
-                iconName: "open"
-                iconColor: win.mutedColor
-                tooltip: "Open"
-                onClicked: backend.openDialog()
+                FooterIconButton {
+                    objectName: "saveButton"
+                    iconName: "save"
+                    iconColor: win.mutedColor
+                    tooltip: "Save"
+                    onClicked: backend.save()
+                }
+
+                FooterIconButton {
+                    objectName: "openButton"
+                    iconName: "open"
+                    iconColor: win.mutedColor
+                    tooltip: "Open"
+                    onClicked: backend.openDialog()
+                }
+
+                Label {
+                    text: backend.status
+                    color: win.mutedColor
+                    font.family: "iA Writer Mono S"
+                    font.pixelSize: win.scaledSize(11)
+                    visible: text !== ""
+                    elide: Text.ElideRight
+                    width: Math.min(360, win.width / 3)
+                    height: win.scaledSize(16)
+                    verticalAlignment: Text.AlignVCenter
+                }
             }
 
             Label {
-                text: backend.status
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                anchors.rightMargin: 12
+                anchors.bottomMargin: 10
+                text: backend.wordCount + (backend.wordCount === 1 ? " Word" : " Words")
                 color: win.mutedColor
+                opacity: 0.75
                 font.family: "iA Writer Mono S"
                 font.pixelSize: win.scaledSize(11)
-                visible: text !== ""
-                elide: Text.ElideRight
-                width: Math.min(360, win.width / 3)
-                height: win.scaledSize(16)
-                verticalAlignment: Text.AlignVCenter
             }
         }
-
-        Label {
-            anchors.right: parent.right
-            anchors.bottom: parent.bottom
-            anchors.rightMargin: 12
-            anchors.bottomMargin: 10
-            text: backend.wordCount + (backend.wordCount === 1 ? " Word" : " Words")
-            color: win.mutedColor
-            opacity: 0.75
-            font.family: "iA Writer Mono S"
-            font.pixelSize: win.scaledSize(11)
-        }
-
 
         Pane {
             anchors.top: parent.top

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -1,5 +1,7 @@
 #include <QtTest>
+#include <QColor>
 #include <QFont>
+#include <QQuickItem>
 #include <QQmlComponent>
 #include <QQmlContext>
 #include <QQmlEngine>
@@ -190,6 +192,40 @@ private slots:
         QSignalSpy openDialogSpy(&backend, &Backend::openDialogRequested);
         QVERIFY(QMetaObject::invokeMethod(openButton, "clicked"));
         QCOMPARE(openDialogSpy.count(), 1);
+    }
+
+    void reservesAnOpaqueFooterBelowTheEditor() {
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        Backend backend;
+        QQmlEngine engine;
+        engine.rootContext()->setContextProperty(QStringLiteral("backend"), &backend);
+        QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> window(component.create());
+        QVERIFY2(window, qPrintable(component.errorString()));
+
+        auto *footer = window->findChild<QQuickItem *>(QStringLiteral("footer"));
+        auto *editorViewport = window->findChild<QQuickItem *>(
+            QStringLiteral("editorViewport"));
+        auto *saveButton = window->findChild<QQuickItem *>(QStringLiteral("saveButton"));
+        QVERIFY(footer);
+        QVERIFY(editorViewport);
+        QVERIFY(saveButton);
+
+        QCOMPARE(footer->opacity(), qreal(1));
+        const QColor footerColor = footer->property("color").value<QColor>();
+        QCOMPARE(footerColor.alpha(), 255);
+        QCOMPARE(footerColor, QColor(backend.themeBackground()));
+        QCOMPARE(editorViewport->mapToScene(QPointF(0, editorViewport->height())).y(),
+                 footer->mapToScene(QPointF()).y());
+
+        backend.setTextScale(0.5);
+        QVERIFY(saveButton->mapToScene(QPointF()).y()
+                >= footer->mapToScene(QPointF()).y());
+        QCOMPARE(editorViewport->mapToScene(QPointF(0, editorViewport->height())).y(),
+                 footer->mapToScene(QPointF()).y());
     }
 
     void scalesTextWithDesktopTextSize() {


### PR DESCRIPTION
The footer controls and status text currently float over the editor. At some text sizes, document text and the caret remain visible underneath, causing the footer and document content to overlap.

This gives the full-width footer an opaque surface using the active theme background and clips the editor viewport exactly at the footer's top edge. The footer retains a minimum height so its fixed-size controls remain inside the opaque region at the smallest supported desktop text scale.

The save and open controls, status display, word count, theme behavior, text scaling, and search overlay remain unchanged.

## Before
<img width="1267" height="240" alt="footer-before" src="https://github.com/user-attachments/assets/8507cb0a-4db8-4bd4-a40e-0eaf52a9fcf4" />

## After
<img width="1267" height="240" alt="footer-after" src="https://github.com/user-attachments/assets/9ddd4af3-53a8-44fc-9d46-5484d1407e8a" />
