### PR TITLE
feat: add a rendered preview mode toggled with Ctrl+/

### DIFF
--- a/src/FooterIconButton.qml
+++ b/src/FooterIconButton.qml
@@ -54,6 +54,13 @@ Item {
                 context.lineTo(4.5, 9.5);
                 context.lineTo(11.5, 9.5);
                 context.lineTo(11.5, 13.5);
+            } else if (control.iconName === "preview") {
+                context.moveTo(1.5, 8);
+                context.bezierCurveTo(4.5, 4, 11.5, 4, 14.5, 8);
+                context.bezierCurveTo(11.5, 12, 4.5, 12, 1.5, 8);
+                context.closePath();
+                context.moveTo(10, 8);
+                context.arc(8, 8, 2, 0, Math.PI * 2);
             } else {
                 context.moveTo(2.5, 13);
                 context.lineTo(2.5, 3.5);

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -38,6 +38,14 @@ ApplicationWindow {
     property string pendingAction: ""
     property bool replaceOpen: false
     property bool awaitingPendingSave: false
+    property bool previewMode: false
+
+    // Typora parity: Ctrl+/ swaps the source buffer for a rendered view.
+    function togglePreview() {
+        previewMode = !previewMode;
+        if (!previewMode)
+            editor.forceActiveFocus();
+    }
 
     Material.theme: darkMode ? Material.Dark : Material.Light
     Material.accent: backend.themeAccent
@@ -170,6 +178,12 @@ ApplicationWindow {
         sequence: "Ctrl+K"
         context: Qt.WindowShortcut
         onActivated: editor.insertLink()
+    }
+
+    Shortcut {
+        sequence: "Ctrl+/"
+        context: Qt.ApplicationShortcut
+        onActivated: win.togglePreview()
     }
 
     Shortcut {
@@ -331,7 +345,7 @@ ApplicationWindow {
         standardButtons: Dialog.Close
         anchors.centerIn: parent
         contentItem: Label {
-            text: "Ctrl+S  Save\nCtrl+Shift+S  Save As\nCtrl+O  Open\nCtrl+N  New Window\nCtrl+F  Find\nCtrl+H  Find and Replace\nCtrl+B  Bold\nCtrl+I  Italic\nCtrl+K  Link\nCtrl+P  Print\nF11 / Super+F  Fullscreen\nCtrl+?  Shortcuts"
+            text: "Ctrl+S  Save\nCtrl+Shift+S  Save As\nCtrl+O  Open\nCtrl+N  New Window\nCtrl+F  Find\nCtrl+H  Find and Replace\nCtrl+B  Bold\nCtrl+I  Italic\nCtrl+K  Link\nCtrl+/  Preview\nCtrl+P  Print\nF11 / Super+F  Fullscreen\nCtrl+?  Shortcuts"
             lineHeight: 1.5
         }
     }
@@ -346,7 +360,8 @@ ApplicationWindow {
             anchors.rightMargin: 24
             clip: true
             contentWidth: width
-            contentHeight: Math.max(height, editor.y + editor.implicitHeight + 220)
+            contentHeight: Math.max(height, (win.previewMode ? preview.y + preview.implicitHeight
+                                                             : editor.y + editor.implicitHeight) + 220)
             boundsBehavior: Flickable.StopAtBounds
             ScrollBar.vertical: ScrollBar {
                 policy: ScrollBar.AsNeeded
@@ -532,6 +547,7 @@ ApplicationWindow {
             TextEdit {
                 id: editor
                 objectName: "sourceEditor"
+                visible: !win.previewMode
                 x: Math.round((editorFlick.width - width) / 2)
                 y: Math.max(42, Math.round(win.height * 0.05))
                 width: win.editorWidth
@@ -794,6 +810,45 @@ ApplicationWindow {
                     forceActiveFocus();
                 }
             }
+
+            // Read-only rendered view. Qt renders the Markdown itself, so it
+            // shows real heading sizes and list structure the highlighter can
+            // only tint in place. It never calls attachDocument, so the
+            // highlighter stays bound to the source editor alone.
+            TextEdit {
+                id: preview
+                objectName: "previewView"
+                visible: win.previewMode
+                x: Math.round((editorFlick.width - width) / 2)
+                y: editor.y
+                width: win.editorWidth
+                height: Math.max(editorFlick.height - y - 96, implicitHeight + 20)
+                textFormat: TextEdit.RichText
+                wrapMode: TextEdit.Wrap
+                readOnly: true
+                selectByMouse: true
+                persistentSelection: true
+                color: win.textColor
+                selectedTextColor: win.strongTextColor
+                selectionColor: win.selectionFill
+                font.family: "iA Writer Mono S"
+                font.pixelSize: win.editorFontPixelSize
+                font.weight: Font.Normal
+                renderType: Screen.devicePixelRatio % 1 === 0 ? TextEdit.NativeRendering : TextEdit.QtRendering
+                onLinkActivated: function(link) { Qt.openUrlExternally(link); }
+
+                function refresh() {
+                    if (win.previewMode)
+                        backend.renderPreview(textDocument);
+                }
+
+                onVisibleChanged: refresh()
+
+                Connections {
+                    target: editor
+                    function onTextChanged() { preview.refresh(); }
+                }
+            }
         }
 
         Row {
@@ -819,6 +874,14 @@ ApplicationWindow {
                 iconColor: win.mutedColor
                 tooltip: "Open"
                 onClicked: backend.openDialog()
+            }
+
+            FooterIconButton {
+                objectName: "previewButton"
+                iconName: "preview"
+                iconColor: win.previewMode ? backend.themeAccent : win.mutedColor
+                tooltip: win.previewMode ? "Back to source (Ctrl+/)" : "Preview (Ctrl+/)"
+                onClicked: win.togglePreview()
             }
 
             Label {

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -277,6 +277,42 @@ void Backend::keepExternalVersion() {
     setStatus(QStringLiteral("Kept your version"));
 }
 
+void Backend::renderPreview(QObject *textDocument) {
+    auto *quickDocument = qobject_cast<QQuickTextDocument *>(textDocument);
+    if (!quickDocument || !quickDocument->textDocument())
+        return;
+
+    QTextDocument *preview = quickDocument->textDocument();
+    preview->setDefaultFont(m_document ? m_document->defaultFont() : preview->defaultFont());
+    preview->setMarkdown(currentDocumentText());
+
+    // Qt's Markdown reader packs every block flush against the next, so the
+    // blank lines that separate paragraphs in the source disappear from the
+    // render. Put that breathing room back as real block spacing, sized from
+    // the editor font so it tracks the desktop text scale.
+    const qreal gap = preview->defaultFont().pixelSize() > 0
+                          ? preview->defaultFont().pixelSize() * 0.75
+                          : 15.0;
+
+    QTextCursor cursor(preview);
+    cursor.beginEditBlock();
+    for (QTextBlock block = preview->begin(); block.isValid(); block = block.next()) {
+        QTextBlockFormat format = block.blockFormat();
+        const bool heading = format.headingLevel() > 0;
+        const bool listItem = block.textList() != nullptr;
+        const bool quote = format.intProperty(QTextFormat::BlockQuoteLevel) > 0;
+
+        // Headings lead their section, list items stay tight together, and
+        // ordinary paragraphs get a full blank line's worth beneath them.
+        // Quotes need the leading gap too or they read as another list row.
+        format.setTopMargin(heading ? gap * 1.5 : (quote ? gap : 0));
+        format.setBottomMargin(listItem ? gap * 0.2 : gap);
+        cursor.setPosition(block.position());
+        cursor.setBlockFormat(format);
+    }
+    cursor.endEditBlock();
+}
+
 void Backend::printDocument() {
     if (!m_document) {
         setStatus(QStringLiteral("There is no document to print."));

--- a/src/backend.h
+++ b/src/backend.h
@@ -54,6 +54,7 @@ public:
     static QString suggestedFileName(const QString &text);
 
     Q_INVOKABLE void attachDocument(QObject *textDocument);
+    Q_INVOKABLE void renderPreview(QObject *textDocument);
     Q_INVOKABLE void openDialog();
     Q_INVOKABLE void open(const QUrl &url);
     Q_INVOKABLE void save();

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -1,4 +1,7 @@
 #include <QtTest>
+#include <QQuickTextDocument>
+#include <QTextBlock>
+#include <QTextDocument>
 #include <QFont>
 #include <QQmlComponent>
 #include <QQmlContext>
@@ -246,7 +249,135 @@ private slots:
         QCOMPARE(QFileInfo(fallbackUrl.toLocalFile()).absolutePath(), QDir::homePath());
     }
 
+    void togglesPreviewFromFooterButtonAndBack() {
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        Backend backend;
+        QQmlEngine engine;
+        engine.rootContext()->setContextProperty(QStringLiteral("backend"), &backend);
+        QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> window(component.create());
+        QVERIFY2(window, qPrintable(component.errorString()));
+
+        QObject *editor = window->findChild<QObject *>(QStringLiteral("sourceEditor"));
+        QObject *preview = window->findChild<QObject *>(QStringLiteral("previewView"));
+        QObject *previewButton = window->findChild<QObject *>(QStringLiteral("previewButton"));
+        QVERIFY(editor);
+        QVERIFY(preview);
+        QVERIFY(previewButton);
+
+        // Source is the default: the editor is the visible surface.
+        QVERIFY(!window->property("previewMode").toBool());
+        QVERIFY(editor->property("visible").toBool());
+        QVERIFY(!preview->property("visible").toBool());
+
+        QVERIFY(QMetaObject::invokeMethod(previewButton, "clicked"));
+        QVERIFY(window->property("previewMode").toBool());
+        QVERIFY(!editor->property("visible").toBool());
+        QVERIFY(preview->property("visible").toBool());
+
+        QVERIFY(QMetaObject::invokeMethod(previewButton, "clicked"));
+        QVERIFY(!window->property("previewMode").toBool());
+        QVERIFY(editor->property("visible").toBool());
+        QVERIFY(!preview->property("visible").toBool());
+    }
+
+    void restoresBlockSpacingLostByTheMarkdownReader() {
+        QQmlEngine engine;
+        QScopedPointer<QObject> harness(makeRenderHarness(engine));
+        QVERIFY(harness);
+
+        Backend backend;
+        QTextDocument *rendered = renderThrough(backend, harness.data(),
+            QStringLiteral("# Heading\n\nParagraph one.\n\n- item\n- item\n\n> quoted\n"));
+        QVERIFY(rendered);
+
+        qreal headingTop = -1, paragraphBottom = -1, listBottom = -1, quoteTop = -1;
+        for (QTextBlock block = rendered->begin(); block.isValid(); block = block.next()) {
+            const QTextBlockFormat format = block.blockFormat();
+            if (format.headingLevel() > 0)
+                headingTop = format.topMargin();
+            else if (block.textList())
+                listBottom = format.bottomMargin();
+            else if (format.intProperty(QTextFormat::BlockQuoteLevel) > 0)
+                quoteTop = format.topMargin();
+            else if (block.text().startsWith(QStringLiteral("Paragraph")))
+                paragraphBottom = format.bottomMargin();
+        }
+
+        // Qt's Markdown reader leaves every block flush against the next; the
+        // render pass is the only thing putting the source's blank lines back.
+        QVERIFY2(paragraphBottom > 0, "paragraphs must gain a trailing gap");
+        QVERIFY2(headingTop > 0, "headings must lead their section");
+        QVERIFY2(quoteTop > 0, "quotes need a leading gap or they read as a list row");
+        QVERIFY2(listBottom >= 0 && listBottom < paragraphBottom,
+                 "list items stay tighter than paragraphs");
+    }
+
+    void collapsesRunsOfBlankLinesToOneGap() {
+        QQmlEngine engine;
+        QScopedPointer<QObject> harness(makeRenderHarness(engine));
+        QVERIFY(harness);
+
+        // CommonMark treats any run of blank lines as one block separator, so
+        // the render must not grow with the number of newlines in the source.
+        const auto spacingOf = [&](const QString &markdown) {
+            Backend backend;
+            QTextDocument *rendered = renderThrough(backend, harness.data(), markdown);
+            QList<qreal> margins;
+            if (rendered) {
+                for (QTextBlock block = rendered->begin(); block.isValid();
+                     block = block.next())
+                    margins.append(block.blockFormat().bottomMargin());
+            }
+            return margins;
+        };
+
+        const QList<qreal> single = spacingOf(QStringLiteral("A.\n\nB.\n"));
+        const QList<qreal> quadruple = spacingOf(QStringLiteral("A.\n\n\n\n\nB.\n"));
+        QCOMPARE(single.size(), 2);
+        QCOMPARE(quadruple, single);
+    }
+
 private:
+    // Two TextEdits standing in for the real pair: one the highlighter binds to,
+    // one the preview renders into.
+    static QObject *makeRenderHarness(QQmlEngine &engine) {
+        auto *component = new QQmlComponent(&engine, &engine);
+        component->setData(R"QML(
+            import QtQuick
+            Item {
+                property alias source: sourceEdit
+                property alias rendered: renderedEdit
+                TextEdit { id: sourceEdit }
+                TextEdit { id: renderedEdit }
+            }
+        )QML", QUrl());
+        if (!component->isReady())
+            return nullptr;
+        return component->create();
+    }
+
+    static QTextDocument *renderThrough(Backend &backend, QObject *harness,
+                                        const QString &markdown) {
+        QObject *source = harness->property("source").value<QObject *>();
+        QObject *rendered = harness->property("rendered").value<QObject *>();
+        if (!source || !rendered)
+            return nullptr;
+
+        auto *sourceDocument = source->property("textDocument").value<QQuickTextDocument *>();
+        auto *renderedDocument = rendered->property("textDocument").value<QQuickTextDocument *>();
+        if (!sourceDocument || !renderedDocument)
+            return nullptr;
+
+        backend.attachDocument(sourceDocument);
+        source->setProperty("text", markdown);
+        backend.renderPreview(renderedDocument);
+        return renderedDocument->textDocument();
+    }
+
     QTemporaryDir m_settingsDirectory;
 };
 


### PR DESCRIPTION
## Read this first: this reverses a deliberate decision

Preview mode was in the first commit and **you removed it yourself** in ad65d2f ("Replace preview with footer file controls", 23 Jul), along with regression tests asserting it stays gone:

```cpp
QVERIFY(!window->findChild<QObject *>(QStringLiteral("renderedPreview")));
QVERIFY(!window->findChild<QObject *>(QStringLiteral("modeToggle")));
```

**Those assertions pass on this branch, but only because I named things `previewView` and `previewButton`.** That is a naming accident, not a design agreement. If the intent of that commit was "no preview in this app", this PR contradicts it and you should close it — no hard feelings, and I would rather say that here than have it discovered in review.

I am opening it because #3 is still open with people asking for the feature, and because the commit message gives no rationale, so I could not tell whether the removal was "not like this" or "not ever". If it was the former, this is a concrete proposal. If the latter, say the word and I will close it and add the guard for the new names myself.

## What it does

`Ctrl+/` (Typora's Source Code Mode key) or the eye button in the footer, beside Save and Open, swaps the source buffer for a rendered view. The original used `Ctrl+E`; I went with `Ctrl+/` for Typora parity, but `Ctrl+E` is a one-line change if you prefer the old binding.

| Source (default) | Preview |
|---|---|
| ![source](https://raw.githubusercontent.com/cristim/omawrite/assets/preview-screenshots/screenshots/preview-off-source.png) | ![preview](https://raw.githubusercontent.com/cristim/omawrite/assets/preview-screenshots/screenshots/preview-on-rendered.png) |

## How

The preview is a separate read-only `TextEdit`. It never calls `attachDocument`, so `MarkdownHighlighter` stays bound to the source editor alone and the editing path is untouched.

Rendering goes through `Backend::renderPreview`, which runs `setMarkdown` and then restores block spacing. Qt's Markdown reader packs every block flush against the next, so the blank lines that separate paragraphs in the source vanish from the render. The pass gives headings a leading gap, keeps list items tight, separates blockquotes (via `QTextFormat::BlockQuoteLevel`), and puts a blank line's worth beneath ordinary paragraphs — sized from the editor font so it tracks the desktop text scale.

Multiple consecutive blank lines collapse to one gap. That is deliberate: CommonMark treats them as equivalent, and the `Ctrl+P` path already renders them that way.

## Verification

- `bin/test` — 12 passed, 0 failed, including the two assertions above.
- Built and exercised by hand: toggle both ways, edit in source and re-enter preview, links open externally, footer icon takes the theme accent while active.

## Known gaps

- Built and tested on **macOS** against Homebrew Qt 6.11.1, not on Omarchy. The D-Bus portal path is untouched, but I cannot claim a Linux run.
- The original had separate scroll positions per mode and forced `previewMode = false` on Find/Replace. I did not restore either; both are worth adding if this direction is acceptable at all.
