### PR TITLE
Count Han and kana characters as words

### DIFF
--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -679,8 +679,10 @@ QString Backend::currentDocumentText() const {
 }
 
 int Backend::countWords(const QString &text) {
+    // Only letters and numbers: PCRE2 reads \p{Han} as Script_Extensions, which
+    // puts 。 、 「 and the CJK radicals in Han and would count each as a word.
     static const QRegularExpression cjkRe(
-        QStringLiteral("[\\p{Han}\\p{Hiragana}\\p{Katakana}]"));
+        QStringLiteral("(?=[\\p{L}\\p{N}])[\\p{Han}\\p{Hiragana}\\p{Katakana}]"));
     static const QRegularExpression wordRe(
         QStringLiteral("[\\p{L}\\p{N}]+(?:['-][\\p{L}\\p{N}]+)*"));
 

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -679,10 +679,25 @@ QString Backend::currentDocumentText() const {
 }
 
 int Backend::countWords(const QString &text) {
+    static const QRegularExpression cjkRe(
+        QStringLiteral("[\\p{Han}\\p{Hiragana}\\p{Katakana}]"));
     static const QRegularExpression wordRe(
         QStringLiteral("[\\p{L}\\p{N}]+(?:['-][\\p{L}\\p{N}]+)*"));
+
+    // Count unspaced Han and kana characters individually, then replace them
+    // so they remain boundaries between surrounding space-delimited words.
     int count = 0;
-    QRegularExpressionMatchIterator it = wordRe.globalMatch(text);
+
+    QRegularExpressionMatchIterator cjkIt = cjkRe.globalMatch(text);
+    while (cjkIt.hasNext()) {
+        cjkIt.next();
+        ++count;
+    }
+
+    QString nonCjkText = text;
+    nonCjkText.replace(cjkRe, QStringLiteral(" "));
+
+    QRegularExpressionMatchIterator it = wordRe.globalMatch(nonCjkText);
     while (it.hasNext()) {
         it.next();
         ++count;

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -29,6 +29,7 @@ private slots:
         QCOMPARE(Backend::countWords(QStringLiteral("日本語テスト")), 6);
         QCOMPARE(Backend::countWords(QStringLiteral("你好，世界。")), 4);
         QCOMPARE(Backend::countWords(QStringLiteral("コーヒー")), 4);
+        QCOMPARE(Backend::countWords(QStringLiteral("か\u3099")), 1); // が, decomposed
         QCOMPARE(Backend::countWords(QStringLiteral("𠀀𠀁 foo")), 3);
         QCOMPARE(Backend::countWords(QStringLiteral("안녕하세요 세계")), 2);
         QCOMPARE(Backend::countWords(QString()), 0);

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -22,7 +22,11 @@ private slots:
 
     void countsWords() {
         QCOMPARE(Backend::countWords(QStringLiteral("one two-three don't 42")), 4);
-        QCOMPARE(Backend::countWords(QStringLiteral("你好 世界")), 2);
+        QCOMPARE(Backend::countWords(QStringLiteral("你好世界")), 4);
+        QCOMPARE(Backend::countWords(QStringLiteral("你好 世界")), 4);
+        QCOMPARE(Backend::countWords(QStringLiteral("中文 iPad AI")), 4);
+        QCOMPARE(Backend::countWords(QStringLiteral("foo中bar")), 3);
+        QCOMPARE(Backend::countWords(QStringLiteral("日本語テスト")), 6);
         QCOMPARE(Backend::countWords(QString()), 0);
     }
 

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -27,6 +27,10 @@ private slots:
         QCOMPARE(Backend::countWords(QStringLiteral("中文 iPad AI")), 4);
         QCOMPARE(Backend::countWords(QStringLiteral("foo中bar")), 3);
         QCOMPARE(Backend::countWords(QStringLiteral("日本語テスト")), 6);
+        QCOMPARE(Backend::countWords(QStringLiteral("你好，世界。")), 4);
+        QCOMPARE(Backend::countWords(QStringLiteral("コーヒー")), 4);
+        QCOMPARE(Backend::countWords(QStringLiteral("𠀀𠀁 foo")), 3);
+        QCOMPARE(Backend::countWords(QStringLiteral("안녕하세요 세계")), 2);
         QCOMPARE(Backend::countWords(QString()), 0);
     }
 


### PR DESCRIPTION
## Summary

- Count each Han, hiragana, and katakana character as one word unit.
- Preserve the existing Latin and numeric word rules, including hyphens and apostrophes.
- Treat Han and kana characters as boundaries in mixed text.

## Why

The current regular expression treats each unspaced Chinese or Japanese phrase as one word. A Chinese draft with 345 Han characters and two Latin words therefore showed 45 Words. With this change it shows 347 Words, with no UI change and no difference for English-only documents.

## Before

The draft is counted as 45 Words.

![Before: Chinese draft counted as 45 Words](https://raw.githubusercontent.com/wulujia/omawrite/95cec7c7aab843def08e2f43830066007275ef18/20260903-pr-52-before.png)

## After

The same draft is counted as 347 Words.

![After: Chinese draft counted as 347 Words](https://raw.githubusercontent.com/wulujia/omawrite/95cec7c7aab843def08e2f43830066007275ef18/20260903-pr-52-after.png)

## Testing

- ./bin/test
- ./bin/build