### PR TITLE
Remember the writing workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build/
 /build-tests/
+/.worktrees/
 /pkg/
 /pkgbuild/pkg/
 /pkgbuild/src/

--- a/bin/test
+++ b/bin/test
@@ -14,4 +14,4 @@ mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
 "$QMAKE" "$ROOT/tests/tests.pro"
 make -j"$(nproc 2>/dev/null || echo 1)"
-QT_QPA_PLATFORM=offscreen ./tst_omawrite
+QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME= ./tst_omawrite

--- a/omawrite.pro
+++ b/omawrite.pro
@@ -6,6 +6,7 @@ TEMPLATE = app
 
 HEADERS += \
     src/buffersession.h \
+    src/workspacesession.h \
     src/backend.h \
     src/markdownhighlighter.h \
     src/systemtheme.h
@@ -13,6 +14,7 @@ HEADERS += \
 SOURCES += \
     src/main.cpp \
     src/buffersession.cpp \
+    src/workspacesession.cpp \
     src/backend.cpp \
     src/markdownhighlighter.cpp \
     src/systemtheme.cpp

--- a/omawrite.pro
+++ b/omawrite.pro
@@ -5,12 +5,14 @@ TARGET = omawrite
 TEMPLATE = app
 
 HEADERS += \
+    src/buffersession.h \
     src/backend.h \
     src/markdownhighlighter.h \
     src/systemtheme.h
 
 SOURCES += \
     src/main.cpp \
+    src/buffersession.cpp \
     src/backend.cpp \
     src/markdownhighlighter.cpp \
     src/systemtheme.cpp

--- a/omawrite.pro
+++ b/omawrite.pro
@@ -7,6 +7,7 @@ TEMPLATE = app
 HEADERS += \
     src/buffersession.h \
     src/workspacesession.h \
+    src/windowmanager.h \
     src/backend.h \
     src/markdownhighlighter.h \
     src/systemtheme.h
@@ -15,6 +16,7 @@ SOURCES += \
     src/main.cpp \
     src/buffersession.cpp \
     src/workspacesession.cpp \
+    src/windowmanager.cpp \
     src/backend.cpp \
     src/markdownhighlighter.cpp \
     src/systemtheme.cpp

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -194,27 +194,45 @@ ApplicationWindow {
     }
 
     Shortcut {
+        objectName: "newTabShortcut"
         sequence: "Ctrl+T"
-        context: Qt.ApplicationShortcut
+        context: Qt.WindowShortcut
         onActivated: backend.newBuffer()
     }
 
     Shortcut {
+        objectName: "closeTabShortcut"
         sequence: "Ctrl+W"
-        context: Qt.ApplicationShortcut
+        context: Qt.WindowShortcut
         onActivated: win.requestCloseTab()
     }
 
     Shortcut {
+        objectName: "nextTabShortcut"
         sequence: "Ctrl+Tab"
-        context: Qt.ApplicationShortcut
+        context: Qt.WindowShortcut
         onActivated: win.selectAdjacentTab(1)
     }
 
     Shortcut {
+        objectName: "previousTabShortcut"
         sequence: "Ctrl+Shift+Tab"
-        context: Qt.ApplicationShortcut
+        context: Qt.WindowShortcut
         onActivated: win.selectAdjacentTab(-1)
+    }
+
+    Shortcut {
+        objectName: "moveTabLeftShortcut"
+        sequence: "Ctrl+Shift+PgUp"
+        context: Qt.WindowShortcut
+        onActivated: backend.moveActiveBuffer(-1)
+    }
+
+    Shortcut {
+        objectName: "moveTabRightShortcut"
+        sequence: "Ctrl+Shift+PgDown"
+        context: Qt.WindowShortcut
+        onActivated: backend.moveActiveBuffer(1)
     }
 
     Shortcut {
@@ -259,8 +277,9 @@ ApplicationWindow {
     }
 
     Shortcut {
+        objectName: "newWindowShortcut"
         sequence: "Ctrl+N"
-        context: Qt.ApplicationShortcut
+        context: Qt.WindowShortcut
         onActivated: backend.newWindow()
     }
 
@@ -409,7 +428,7 @@ ApplicationWindow {
         standardButtons: Dialog.Close
         anchors.centerIn: parent
         contentItem: Label {
-            text: "Ctrl+S  Save\nCtrl+Shift+S  Save As\nCtrl+O  Open\nCtrl+T  New Tab\nCtrl+W  Close Tab\nCtrl+Tab  Next Tab\nCtrl+Shift+Tab  Previous Tab\nCtrl+N  New Window\nCtrl+F  Find\nCtrl+H  Find and Replace\nCtrl+B  Bold\nCtrl+I  Italic\nCtrl+K  Link\nCtrl+P  Print\nF11 / Super+F  Fullscreen\nCtrl+?  Shortcuts"
+            text: "Ctrl+S  Save\nCtrl+Shift+S  Save As\nCtrl+O  Open\nCtrl+T  New Tab\nCtrl+W  Close Tab\nCtrl+Tab  Next Tab\nCtrl+Shift+Tab  Previous Tab\nCtrl+Shift+PgUp  Move Tab Left\nCtrl+Shift+PgDown  Move Tab Right\nCtrl+N  New Window\nCtrl+F  Find\nCtrl+H  Find and Replace\nCtrl+B  Bold\nCtrl+I  Italic\nCtrl+K  Link\nCtrl+P  Print\nF11 / Super+F  Fullscreen\nCtrl+?  Shortcuts"
             lineHeight: 1.5
         }
     }

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -92,6 +92,28 @@ ApplicationWindow {
         }
     }
 
+    function ensureActiveTabVisible() {
+        for (var index = 0; index < backend.buffers.length; ++index) {
+            if (backend.buffers[index].id !== backend.activeBufferId)
+                continue;
+
+            var tab = tabRepeater.itemAt(index);
+            if (!tab) {
+                activeTabVisibilityTimer.restart();
+                return;
+            }
+
+            if (tab.x < tabFlick.contentX) {
+                tabFlick.contentX = tab.x;
+                return;
+            }
+
+            if (tab.x + tab.width > tabFlick.contentX + tabFlick.width)
+                tabFlick.contentX = tab.x + tab.width - tabFlick.width;
+            return;
+        }
+    }
+
     function completePendingAction() {
         var action = pendingAction;
         pendingAction = "";
@@ -184,6 +206,20 @@ ApplicationWindow {
             editor.cursorPosition = backend.activeCursorPosition;
             editorFlick.ensureCursorVisible();
             backend.finishActiveBufferRestore();
+        }
+    }
+
+    Timer {
+        id: activeTabVisibilityTimer
+        interval: 0
+        repeat: false
+        onTriggered: win.ensureActiveTabVisible()
+    }
+
+    Connections {
+        target: backend
+        function onActiveBufferIdChanged() {
+            activeTabVisibilityTimer.restart();
         }
     }
 
@@ -464,6 +500,7 @@ ApplicationWindow {
                     spacing: 4
 
                     Repeater {
+                        id: tabRepeater
                         model: backend.buffers
                         delegate: Rectangle {
                             required property var modelData

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -74,6 +74,11 @@ ApplicationWindow {
         unsavedChangesDialog.open();
     }
 
+    function scrollTabs(direction) {
+        tabFlick.contentX = Math.max(0, Math.min(tabFlick.contentWidth - tabFlick.width,
+                                                  tabFlick.contentX + direction * tabFlick.width * 0.75));
+    }
+
     function completePendingAction() {
         var action = pendingAction;
         pendingAction = "";
@@ -387,45 +392,122 @@ ApplicationWindow {
     Item {
         anchors.fill: parent
 
-        Row {
-            id: tabStrip
+        Item {
+            id: tabBar
+            objectName: "tabBar"
             anchors.top: parent.top
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.topMargin: 8
             anchors.leftMargin: 12
             anchors.rightMargin: 12
-            spacing: 4
+            height: 28
+            visible: backend.buffers.length > 1
             z: 2
 
-            Repeater {
-                model: backend.buffers
-                delegate: Rectangle {
-                    required property var modelData
-                    required property int index
-                    width: tabLabel.implicitWidth + 20
-                    height: 28
-                    color: modelData.id === backend.activeBufferId
-                        ? backend.themeAccent
-                        : (win.darkMode ? "#252525" : "#e7e7e7")
+            Flickable {
+                id: tabFlick
+                objectName: "tabFlick"
+                anchors.fill: parent
+                clip: true
+                contentWidth: tabStrip.width
+                contentHeight: height
+                flickableDirection: Flickable.HorizontalFlick
+                boundsBehavior: Flickable.StopAtBounds
 
-                    Label {
-                        id: tabLabel
-                        anchors.centerIn: parent
-                        text: (modelData.modified ? "* " : "")
-                            + backend.bufferTitle(modelData, index)
-                        color: modelData.id === backend.activeBufferId
-                            ? "white"
-                            : win.textColor
-                        font.family: "iA Writer Mono S"
-                        font.pixelSize: win.scaledSize(11)
-                    }
+                Row {
+                    id: tabStrip
+                    spacing: 4
 
-                    MouseArea {
-                        anchors.fill: parent
-                        cursorShape: Qt.PointingHandCursor
-                        onClicked: backend.selectBuffer(modelData.id)
+                    Repeater {
+                        model: backend.buffers
+                        delegate: Rectangle {
+                            required property var modelData
+                            required property int index
+                            width: tabLabel.implicitWidth + 20
+                            height: 28
+                            color: modelData.id === backend.activeBufferId
+                                ? backend.themeAccent
+                                : (win.darkMode ? "#252525" : "#e7e7e7")
+
+                            Label {
+                                id: tabLabel
+                                anchors.centerIn: parent
+                                text: (modelData.modified ? "* " : "")
+                                    + backend.bufferTitle(modelData, index)
+                                color: modelData.id === backend.activeBufferId
+                                    ? "white"
+                                    : win.textColor
+                                font.family: "iA Writer Mono S"
+                                font.pixelSize: win.scaledSize(11)
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: backend.selectBuffer(modelData.id)
+                            }
+                        }
                     }
+                }
+
+                WheelHandler {
+                    acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+                    onWheel: function(wheel) {
+                        var delta = wheel.pixelDelta.x !== 0 ? wheel.pixelDelta.x : wheel.pixelDelta.y;
+                        if (delta === 0)
+                            delta = wheel.angleDelta.x !== 0 ? wheel.angleDelta.x : wheel.angleDelta.y;
+                        win.scrollTabs(delta > 0 ? -1 : 1);
+                        wheel.accepted = true;
+                    }
+                }
+            }
+
+            Rectangle {
+                id: leftTabScroll
+                objectName: "leftTabScroll"
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                width: 24
+                height: parent.height
+                visible: tabFlick.contentX > 0
+                color: win.darkMode ? "#181818" : "#f4f4f4"
+                z: 1
+
+                Label {
+                    anchors.centerIn: parent
+                    text: "‹"
+                    color: win.textColor
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: win.scrollTabs(-1)
+                }
+            }
+
+            Rectangle {
+                id: rightTabScroll
+                objectName: "rightTabScroll"
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                width: 24
+                height: parent.height
+                visible: tabFlick.contentX + tabFlick.width < tabFlick.contentWidth
+                color: win.darkMode ? "#181818" : "#f4f4f4"
+                z: 1
+
+                Label {
+                    anchors.centerIn: parent
+                    text: "›"
+                    color: win.textColor
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: win.scrollTabs(1)
                 }
             }
         }

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -148,6 +148,14 @@ ApplicationWindow {
         editor.forceActiveFocus();
     }
 
+    function restoreActiveCursor() {
+        Qt.callLater(function() {
+            editor.select(backend.activeSelectionStart, backend.activeSelectionEnd);
+            editor.cursorPosition = backend.activeCursorPosition;
+            editorFlick.ensureCursorVisible();
+        });
+    }
+
     Shortcut {
         sequence: "Ctrl+S"
         context: Qt.ApplicationShortcut
@@ -287,6 +295,10 @@ ApplicationWindow {
             externalChangeDialog.deleted = deleted;
             externalChangeDialog.locallyModified = locallyModified;
             externalChangeDialog.open();
+        }
+
+        function onActiveBufferChanged() {
+            win.restoreActiveCursor();
         }
     }
 
@@ -864,6 +876,7 @@ ApplicationWindow {
 
                 Component.onCompleted: {
                     backend.attachDocument(textDocument);
+                    win.restoreActiveCursor();
                     forceActiveFocus();
                 }
             }

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -477,7 +477,8 @@ ApplicationWindow {
                             Label {
                                 id: tabLabel
                                 anchors.centerIn: parent
-                                text: (modelData.modified ? "* " : "")
+                                text: (modelData.externalChanged ? "• " : "")
+                                    + (modelData.modified ? "* " : "")
                                     + backend.bufferTitle(modelData, index)
                                 color: modelData.id === backend.activeBufferId
                                     ? "white"

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -144,6 +144,18 @@ ApplicationWindow {
     }
 
     Shortcut {
+        sequence: "Ctrl+T"
+        context: Qt.ApplicationShortcut
+        onActivated: backend.newBuffer()
+    }
+
+    Shortcut {
+        sequence: "Ctrl+W"
+        context: Qt.ApplicationShortcut
+        onActivated: backend.closeActiveBuffer()
+    }
+
+    Shortcut {
         sequence: "Ctrl+H"
         context: Qt.ApplicationShortcut
         onActivated: {
@@ -339,6 +351,31 @@ ApplicationWindow {
     Item {
         anchors.fill: parent
 
+        Row {
+            id: tabStrip
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.topMargin: 8
+            anchors.leftMargin: 12
+            anchors.rightMargin: 12
+            spacing: 4
+            z: 2
+
+            Repeater {
+                model: backend.buffers
+                delegate: Button {
+                    required property var modelData
+                    text: (modelData.modified ? "* " : "")
+                        + (modelData.fileUrl === "" ? "Untitled.md"
+                           : modelData.fileUrl.split("/").pop())
+                    checked: modelData.id === backend.activeBufferId
+                    checkable: true
+                    onClicked: backend.selectBuffer(modelData.id)
+                }
+            }
+        }
+
         Flickable {
             id: editorFlick
             anchors.fill: parent
@@ -533,7 +570,7 @@ ApplicationWindow {
                 id: editor
                 objectName: "sourceEditor"
                 x: Math.round((editorFlick.width - width) / 2)
-                y: Math.max(42, Math.round(win.height * 0.05))
+                y: Math.max(72, Math.round(win.height * 0.05))
                 width: win.editorWidth
                 height: Math.max(editorFlick.height - y - 96, implicitHeight + 20)
                 text: ""
@@ -559,6 +596,12 @@ ApplicationWindow {
                     color: win.strongTextColor
                 }
                 onCursorRectangleChanged: editorFlick.ensureCursorVisible()
+                onCursorPositionChanged: backend.updateActiveEditorState(cursorPosition,
+                                                                           selectionStart, selectionEnd)
+                onSelectionStartChanged: backend.updateActiveEditorState(cursorPosition,
+                                                                          selectionStart, selectionEnd)
+                onSelectionEndChanged: backend.updateActiveEditorState(cursorPosition,
+                                                                        selectionStart, selectionEnd)
 
                 function replaceSelectionWith(replacement) {
                     var start = Math.min(selectionStart, selectionEnd);
@@ -774,6 +817,7 @@ ApplicationWindow {
                     if (win.searchUpdating)
                         return;
                     var contentChanged = backend.editorTextChanged();
+                    backend.updateActiveEditorState(cursorPosition, selectionStart, selectionEnd);
                     if (win.searchOpen && contentChanged)
                         win.updateSearch();
                 }

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -402,6 +402,7 @@ ApplicationWindow {
                 model: backend.buffers
                 delegate: Rectangle {
                     required property var modelData
+                    required property int index
                     width: tabLabel.implicitWidth + 20
                     height: 28
                     color: modelData.id === backend.activeBufferId
@@ -412,8 +413,7 @@ ApplicationWindow {
                         id: tabLabel
                         anchors.centerIn: parent
                         text: (modelData.modified ? "* " : "")
-                            + (modelData.fileUrl === "" ? "Untitled.md"
-                               : modelData.fileUrl.split("/").pop())
+                            + backend.bufferTitle(modelData, index)
                         color: modelData.id === backend.activeBufferId
                             ? "white"
                             : win.textColor

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -79,6 +79,19 @@ ApplicationWindow {
                                                   tabFlick.contentX + direction * tabFlick.width * 0.75));
     }
 
+    function selectAdjacentTab(direction) {
+        if (backend.buffers.length < 2)
+            return;
+
+        for (var index = 0; index < backend.buffers.length; ++index) {
+            if (backend.buffers[index].id !== backend.activeBufferId)
+                continue;
+            backend.selectBuffer(backend.buffers[(index + direction + backend.buffers.length)
+                                                 % backend.buffers.length].id);
+            return;
+        }
+    }
+
     function completePendingAction() {
         var action = pendingAction;
         pendingAction = "";
@@ -190,6 +203,18 @@ ApplicationWindow {
         sequence: "Ctrl+W"
         context: Qt.ApplicationShortcut
         onActivated: win.requestCloseTab()
+    }
+
+    Shortcut {
+        sequence: "Ctrl+Tab"
+        context: Qt.ApplicationShortcut
+        onActivated: win.selectAdjacentTab(1)
+    }
+
+    Shortcut {
+        sequence: "Ctrl+Shift+Tab"
+        context: Qt.ApplicationShortcut
+        onActivated: win.selectAdjacentTab(-1)
     }
 
     Shortcut {
@@ -384,7 +409,7 @@ ApplicationWindow {
         standardButtons: Dialog.Close
         anchors.centerIn: parent
         contentItem: Label {
-            text: "Ctrl+S  Save\nCtrl+Shift+S  Save As\nCtrl+O  Open\nCtrl+N  New Window\nCtrl+F  Find\nCtrl+H  Find and Replace\nCtrl+B  Bold\nCtrl+I  Italic\nCtrl+K  Link\nCtrl+P  Print\nF11 / Super+F  Fullscreen\nCtrl+?  Shortcuts"
+            text: "Ctrl+S  Save\nCtrl+Shift+S  Save As\nCtrl+O  Open\nCtrl+T  New Tab\nCtrl+W  Close Tab\nCtrl+Tab  Next Tab\nCtrl+Shift+Tab  Previous Tab\nCtrl+N  New Window\nCtrl+F  Find\nCtrl+H  Find and Replace\nCtrl+B  Bold\nCtrl+I  Italic\nCtrl+K  Link\nCtrl+P  Print\nF11 / Super+F  Fullscreen\nCtrl+?  Shortcuts"
             lineHeight: 1.5
         }
     }

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -63,6 +63,15 @@ ApplicationWindow {
         unsavedChangesDialog.open();
     }
 
+    function requestCloseTab() {
+        if (!backend.modified) {
+            backend.closeActiveBuffer();
+            return;
+        }
+        pendingAction = "closeTab";
+        unsavedChangesDialog.open();
+    }
+
     function completePendingAction() {
         var action = pendingAction;
         pendingAction = "";
@@ -71,6 +80,8 @@ ApplicationWindow {
             close();
         } else if (action === "open") {
             backend.open(pendingOpenUrl);
+        } else if (action === "closeTab") {
+            backend.discardActiveBuffer();
         }
     }
 
@@ -152,7 +163,7 @@ ApplicationWindow {
     Shortcut {
         sequence: "Ctrl+W"
         context: Qt.ApplicationShortcut
-        onActivated: backend.closeActiveBuffer()
+        onActivated: win.requestCloseTab()
     }
 
     Shortcut {
@@ -364,14 +375,32 @@ ApplicationWindow {
 
             Repeater {
                 model: backend.buffers
-                delegate: Button {
+                delegate: Rectangle {
                     required property var modelData
-                    text: (modelData.modified ? "* " : "")
-                        + (modelData.fileUrl === "" ? "Untitled.md"
-                           : modelData.fileUrl.split("/").pop())
-                    checked: modelData.id === backend.activeBufferId
-                    checkable: true
-                    onClicked: backend.selectBuffer(modelData.id)
+                    width: tabLabel.implicitWidth + 20
+                    height: 28
+                    color: modelData.id === backend.activeBufferId
+                        ? backend.themeAccent
+                        : (win.darkMode ? "#252525" : "#e7e7e7")
+
+                    Label {
+                        id: tabLabel
+                        anchors.centerIn: parent
+                        text: (modelData.modified ? "* " : "")
+                            + (modelData.fileUrl === "" ? "Untitled.md"
+                               : modelData.fileUrl.split("/").pop())
+                        color: modelData.id === backend.activeBufferId
+                            ? "white"
+                            : win.textColor
+                        font.family: "iA Writer Mono S"
+                        font.pixelSize: win.scaledSize(11)
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: backend.selectBuffer(modelData.id)
+                    }
                 }
             }
         }

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -151,11 +151,22 @@ ApplicationWindow {
     }
 
     function restoreActiveCursor() {
-        Qt.callLater(function() {
-            editor.select(backend.activeSelectionStart, backend.activeSelectionEnd);
+        activeBufferRestoreTimer.restart();
+    }
+
+    Timer {
+        id: activeBufferRestoreTimer
+        interval: 100
+        repeat: false
+        onTriggered: {
+            if (editor.text !== backend.activeBufferText) {
+                restart();
+                return;
+            }
             editor.cursorPosition = backend.activeCursorPosition;
             editorFlick.ensureCursorVisible();
-        });
+            backend.finishActiveBufferRestore();
+        }
     }
 
     Shortcut {
@@ -639,12 +650,18 @@ ApplicationWindow {
                     color: win.strongTextColor
                 }
                 onCursorRectangleChanged: editorFlick.ensureCursorVisible()
-                onCursorPositionChanged: backend.updateActiveEditorState(cursorPosition,
-                                                                           selectionStart, selectionEnd)
-                onSelectionStartChanged: backend.updateActiveEditorState(cursorPosition,
-                                                                          selectionStart, selectionEnd)
-                onSelectionEndChanged: backend.updateActiveEditorState(cursorPosition,
-                                                                        selectionStart, selectionEnd)
+                onCursorPositionChanged: {
+                    if (!backend.restoringActiveBuffer)
+                        backend.updateActiveEditorState(cursorPosition, selectionStart, selectionEnd);
+                }
+                onSelectionStartChanged: {
+                    if (!backend.restoringActiveBuffer)
+                        backend.updateActiveEditorState(cursorPosition, selectionStart, selectionEnd);
+                }
+                onSelectionEndChanged: {
+                    if (!backend.restoringActiveBuffer)
+                        backend.updateActiveEditorState(cursorPosition, selectionStart, selectionEnd);
+                }
 
                 function replaceSelectionWith(replacement) {
                     var start = Math.min(selectionStart, selectionEnd);
@@ -859,6 +876,10 @@ ApplicationWindow {
                 onTextChanged: {
                     if (win.searchUpdating)
                         return;
+                    if (backend.restoringActiveBuffer) {
+                        activeBufferRestoreTimer.restart();
+                        return;
+                    }
                     var contentChanged = backend.editorTextChanged();
                     backend.updateActiveEditorState(cursorPosition, selectionStart, selectionEnd);
                     if (win.searchOpen && contentChanged)

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -44,8 +44,10 @@ ApplicationWindow {
     color: pageColor
 
     onClosing: function(close) {
-        if (closeConfirmed || !backend.modified)
+        if (closeConfirmed || !backend.modified) {
+            backend.prepareForApplicationClose();
             return;
+        }
 
         close.accepted = false;
         pendingAction = "close";

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -72,9 +72,10 @@ QString Backend::normalizedLinkUrl(const QString &clipboardText) {
 }
 
 Backend::Backend(QObject *parent)
-    : QObject(parent),
-      m_bufferSession(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)) {
-    const QString stateDirectory = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    : Backend(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), parent) {}
+
+Backend::Backend(const QString &stateDirectory, QObject *parent)
+    : QObject(parent), m_bufferSession(stateDirectory) {
     QDir().mkpath(stateDirectory);
     if (!m_bufferSession.restore())
         m_bufferSession.createBuffer();
@@ -179,13 +180,22 @@ void Backend::prepareForApplicationClose() {
 }
 
 void Backend::updateActiveEditorState(int cursorPosition, int selectionStart, int selectionEnd) {
-    if (m_applicationClosing)
+    if (!m_document || m_applicationClosing || m_restoringActiveBuffer)
+        return;
+    if (m_ignoringInitialCursorReset && cursorPosition == 0 && m_cursorPosition > 0)
         return;
 
     m_cursorPosition = cursorPosition;
     m_selectionStart = selectionStart;
     m_selectionEnd = selectionEnd;
-    persistActiveBuffer();
+    m_bufferSession.updateBufferCursor(m_bufferSession.activeBufferId(), cursorPosition,
+                                       selectionStart, selectionEnd);
+    m_bufferSession.saveNow();
+}
+
+void Backend::finishActiveBufferRestore() {
+    m_restoringActiveBuffer = false;
+    QTimer::singleShot(250, this, [this]() { m_ignoringInitialCursorReset = false; });
 }
 
 Backend::~Backend() = default;
@@ -231,6 +241,8 @@ void Backend::attachDocument(QObject *textDocument) {
         setStatus(QStringLiteral("Could not attach the Markdown renderer."));
         return;
     }
+
+    m_restoringActiveBuffer = true;
 
     if (m_highlighter)
         delete m_highlighter.data();
@@ -399,7 +411,8 @@ QString Backend::clipboardText() const {
 }
 
 bool Backend::editorTextChanged() {
-    if (m_applicationClosing || m_loading || m_formattingTypography)
+    if (!m_document || m_applicationClosing || m_restoringActiveBuffer || m_loading
+            || m_formattingTypography)
         return false;
 
     const QString text = currentDocumentText();
@@ -506,7 +519,10 @@ void Backend::loadActiveBuffer() {
         m_cursorPosition = buffer.value(QStringLiteral("cursorPosition")).toInt();
         m_selectionStart = buffer.value(QStringLiteral("selectionStart")).toInt();
         m_selectionEnd = buffer.value(QStringLiteral("selectionEnd")).toInt();
-        loadDocumentText(buffer.value(QStringLiteral("text")).toString());
+        m_activeBufferText = buffer.value(QStringLiteral("text")).toString();
+        m_restoringActiveBuffer = true;
+        m_ignoringInitialCursorReset = true;
+        loadDocumentText(m_activeBufferText);
         setFileUrl(QUrl(buffer.value(QStringLiteral("fileUrl")).toString()));
         setModified(buffer.value(QStringLiteral("modified")).toBool());
         return;
@@ -516,8 +532,9 @@ void Backend::loadActiveBuffer() {
 void Backend::persistActiveBuffer() {
     if (m_bufferSession.activeBufferId().isEmpty())
         return;
+    m_activeBufferText = currentDocumentText();
     m_bufferSession.updateBuffer(m_bufferSession.activeBufferId(), m_fileUrl.toString(),
-                                 currentDocumentText(), m_cursorPosition, m_selectionStart,
+                                 m_activeBufferText, m_cursorPosition, m_selectionStart,
                                  m_selectionEnd, m_modified);
     m_bufferSession.saveNow();
 }

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -134,9 +134,30 @@ Backend::Backend(const QString &stateDirectory, QObject *parent)
     });
 }
 
+Backend::Backend(WorkspaceSession *workspaceSession, const QString &windowId, QObject *parent)
+    : QObject(parent), m_bufferSession(QString()), m_workspaceSession(workspaceSession),
+      m_workspaceWindowId(windowId) {
+    for (const QVariant &value : buffers()) {
+        const QVariantMap buffer = value.toMap();
+        if (buffer.value(QStringLiteral("id")).toString() != activeBufferId())
+            continue;
+        m_activeBufferText = buffer.value(QStringLiteral("text")).toString();
+        m_cursorPosition = buffer.value(QStringLiteral("cursorPosition")).toInt();
+        m_selectionStart = buffer.value(QStringLiteral("selectionStart")).toInt();
+        m_selectionEnd = buffer.value(QStringLiteral("selectionEnd")).toInt();
+        m_fileUrl = QUrl(buffer.value(QStringLiteral("fileUrl")).toString());
+        m_modified = buffer.value(QStringLiteral("modified")).toBool();
+        break;
+    }
+    loadOmarchyTheme();
+    watchOmarchyTheme();
+}
+
 QString Backend::newBuffer() {
     persistActiveBuffer();
-    const QString id = m_bufferSession.createBuffer();
+    const QString id = m_workspaceSession
+        ? m_workspaceSession->createTab(m_workspaceWindowId, QUrl(), QString(), 0, 0, 0, false)
+        : m_bufferSession.createBuffer();
     loadActiveBuffer();
     emit buffersChanged();
     emit activeBufferChanged();
@@ -145,7 +166,8 @@ QString Backend::newBuffer() {
 
 bool Backend::selectBuffer(const QString &id) {
     persistActiveBuffer();
-    if (!m_bufferSession.selectBuffer(id))
+    if (m_workspaceSession ? !m_workspaceSession->setActiveTab(m_workspaceWindowId, id)
+                           : !m_bufferSession.selectBuffer(id))
         return false;
     loadActiveBuffer();
     emit activeBufferChanged();
@@ -162,10 +184,14 @@ bool Backend::closeActiveBuffer() {
 }
 
 bool Backend::discardActiveBuffer() {
-    if (!m_bufferSession.closeBuffer(m_bufferSession.activeBufferId()))
+    if (m_workspaceSession ? !m_workspaceSession->removeTab(m_workspaceWindowId, activeBufferId())
+                           : !m_bufferSession.closeBuffer(m_bufferSession.activeBufferId()))
         return false;
     loadActiveBuffer();
-    m_bufferSession.saveNow();
+    if (m_workspaceSession)
+        m_workspaceSession->saveNow();
+    else
+        m_bufferSession.saveNow();
     emit buffersChanged();
     emit activeBufferChanged();
     return true;
@@ -188,9 +214,7 @@ void Backend::updateActiveEditorState(int cursorPosition, int selectionStart, in
     m_cursorPosition = cursorPosition;
     m_selectionStart = selectionStart;
     m_selectionEnd = selectionEnd;
-    m_bufferSession.updateBufferCursor(m_bufferSession.activeBufferId(), cursorPosition,
-                                       selectionStart, selectionEnd);
-    m_bufferSession.saveNow();
+    persistActiveBuffer();
 }
 
 void Backend::finishActiveBufferRestore() {
@@ -531,9 +555,9 @@ void Backend::loadDocumentText(const QString &text) {
 }
 
 void Backend::loadActiveBuffer() {
-    for (const QVariant &value : m_bufferSession.buffers()) {
+    for (const QVariant &value : buffers()) {
         const QVariantMap buffer = value.toMap();
-        if (buffer.value(QStringLiteral("id")).toString() != m_bufferSession.activeBufferId())
+        if (buffer.value(QStringLiteral("id")).toString() != activeBufferId())
             continue;
         m_cursorPosition = buffer.value(QStringLiteral("cursorPosition")).toInt();
         m_selectionStart = buffer.value(QStringLiteral("selectionStart")).toInt();
@@ -549,13 +573,20 @@ void Backend::loadActiveBuffer() {
 }
 
 void Backend::persistActiveBuffer() {
-    if (m_bufferSession.activeBufferId().isEmpty())
+    if (activeBufferId().isEmpty())
         return;
     m_activeBufferText = currentDocumentText();
-    m_bufferSession.updateBuffer(m_bufferSession.activeBufferId(), m_fileUrl.toString(),
-                                 m_activeBufferText, m_cursorPosition, m_selectionStart,
-                                 m_selectionEnd, m_modified);
-    m_bufferSession.saveNow();
+    if (m_workspaceSession) {
+        m_workspaceSession->updateTab(m_workspaceWindowId, activeBufferId(), m_fileUrl,
+                                      m_activeBufferText, m_cursorPosition, m_selectionStart,
+                                      m_selectionEnd, m_modified);
+        m_workspaceSession->saveNow();
+    } else {
+        m_bufferSession.updateBuffer(m_bufferSession.activeBufferId(), m_fileUrl.toString(),
+                                     m_activeBufferText, m_cursorPosition, m_selectionStart,
+                                     m_selectionEnd, m_modified);
+        m_bufferSession.saveNow();
+    }
     emit buffersChanged();
 }
 

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -71,9 +71,13 @@ QString Backend::normalizedLinkUrl(const QString &clipboardText) {
     return url.toString();
 }
 
-Backend::Backend(QObject *parent) : QObject(parent) {
+Backend::Backend(QObject *parent)
+    : QObject(parent),
+      m_bufferSession(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)) {
     const QString stateDirectory = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     QDir().mkpath(stateDirectory);
+    if (!m_bufferSession.restore())
+        m_bufferSession.createBuffer();
     // Claim an orphaned snapshot before taking an empty slot. This ensures a
     // crash in window 2 is still recovered even if window 1 exited normally.
     for (int pass = 0; pass < 2 && !m_recoveryLock; ++pass) {
@@ -127,6 +131,46 @@ Backend::Backend(QObject *parent) : QObject(parent) {
         loadOmarchyTheme();
         watchOmarchyTheme();
     });
+}
+
+QString Backend::newBuffer() {
+    persistActiveBuffer();
+    const QString id = m_bufferSession.createBuffer();
+    loadActiveBuffer();
+    emit buffersChanged();
+    emit activeBufferChanged();
+    return id;
+}
+
+bool Backend::selectBuffer(const QString &id) {
+    persistActiveBuffer();
+    if (!m_bufferSession.selectBuffer(id))
+        return false;
+    loadActiveBuffer();
+    emit activeBufferChanged();
+    return true;
+}
+
+bool Backend::closeActiveBuffer() {
+    persistActiveBuffer();
+    if (m_modified) {
+        setStatus(QStringLiteral("Save or discard changes before closing this tab"));
+        return false;
+    }
+    if (!m_bufferSession.closeBuffer(m_bufferSession.activeBufferId()))
+        return false;
+    loadActiveBuffer();
+    m_bufferSession.saveNow();
+    emit buffersChanged();
+    emit activeBufferChanged();
+    return true;
+}
+
+void Backend::updateActiveEditorState(int cursorPosition, int selectionStart, int selectionEnd) {
+    m_cursorPosition = cursorPosition;
+    m_selectionStart = selectionStart;
+    m_selectionEnd = selectionEnd;
+    persistActiveBuffer();
 }
 
 Backend::~Backend() = default;
@@ -191,7 +235,7 @@ void Backend::attachDocument(QObject *textDocument) {
             });
 
     applyDocumentTypography();
-    restoreRecovery();
+    loadActiveBuffer();
 }
 
 void Backend::openDialog() {
@@ -212,13 +256,14 @@ void Backend::open(const QUrl &url) {
     }
 
     const QByteArray contents = file.readAll();
-    loadDocumentText(QString::fromUtf8(contents));
-    clearRecovery();
+    persistActiveBuffer();
+    m_bufferSession.openBuffer(url, QString::fromUtf8(contents));
+    loadActiveBuffer();
     m_lastKnownFileContents = contents;
     m_hasKnownFileContents = true;
-    setFileUrl(url);
-    watchCurrentFile();
-    setModified(false);
+    m_bufferSession.saveNow();
+    emit buffersChanged();
+    emit activeBufferChanged();
     setStatus(QStringLiteral("Opened %1").arg(fileName()));
 }
 
@@ -272,7 +317,7 @@ void Backend::keepExternalVersion() {
         m_hasKnownFileContents = false;
     }
     setModified(true);
-    scheduleRecovery();
+    persistActiveBuffer();
     watchCurrentFile();
     setStatus(QStringLiteral("Kept your version"));
 }
@@ -357,7 +402,7 @@ bool Backend::editorTextChanged() {
     scheduleWordCount();
     setModified(true);
     setStatus(QStringLiteral("Unsaved"));
-    scheduleRecovery();
+    persistActiveBuffer();
     return true;
 }
 
@@ -438,6 +483,30 @@ void Backend::loadDocumentText(const QString &text) {
     setWordCount(countWords(text));
 }
 
+void Backend::loadActiveBuffer() {
+    for (const QVariant &value : m_bufferSession.buffers()) {
+        const QVariantMap buffer = value.toMap();
+        if (buffer.value(QStringLiteral("id")).toString() != m_bufferSession.activeBufferId())
+            continue;
+        m_cursorPosition = buffer.value(QStringLiteral("cursorPosition")).toInt();
+        m_selectionStart = buffer.value(QStringLiteral("selectionStart")).toInt();
+        m_selectionEnd = buffer.value(QStringLiteral("selectionEnd")).toInt();
+        loadDocumentText(buffer.value(QStringLiteral("text")).toString());
+        setFileUrl(QUrl(buffer.value(QStringLiteral("fileUrl")).toString()));
+        setModified(buffer.value(QStringLiteral("modified")).toBool());
+        return;
+    }
+}
+
+void Backend::persistActiveBuffer() {
+    if (m_bufferSession.activeBufferId().isEmpty())
+        return;
+    m_bufferSession.updateBuffer(m_bufferSession.activeBufferId(), m_fileUrl.toString(),
+                                 currentDocumentText(), m_cursorPosition, m_selectionStart,
+                                 m_selectionEnd, m_modified);
+    m_bufferSession.saveNow();
+}
+
 void Backend::setFileUrl(const QUrl &url) {
     if (m_fileUrl == url)
         return;
@@ -506,7 +575,7 @@ void Backend::saveTo(const QUrl &url) {
                          QFileInfo(url.toLocalFile()).absolutePath());
     setModified(false);
     setStatus(QStringLiteral("Saved %1").arg(fileName()));
-    clearRecovery();
+    persistActiveBuffer();
     emit saveSucceeded();
 
     if (shouldClose)

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -96,42 +96,7 @@ Backend::Backend(const QString &stateDirectory, QObject *parent)
             }
         }
     }
-    m_wordCountTimer.setSingleShot(true);
-    m_wordCountTimer.setInterval(120);
-    connect(&m_wordCountTimer, &QTimer::timeout, this, &Backend::refreshWordCount);
-    m_recoveryTimer.setSingleShot(true);
-    m_recoveryTimer.setInterval(750);
-    connect(&m_recoveryTimer, &QTimer::timeout, this, &Backend::writeRecovery);
-    connect(&m_fileWatcher, &QFileSystemWatcher::fileChanged, this,
-            [this](const QString &path) {
-                if (path != m_fileUrl.toLocalFile())
-                    return;
-
-                const bool deleted = !QFileInfo::exists(path);
-                if (!deleted && m_hasKnownFileContents) {
-                    QFile file(path);
-                    if (file.open(QIODevice::ReadOnly)
-                            && file.readAll() == m_lastKnownFileContents) {
-                        // Atomic saves can replace the watched inode. Re-arm the
-                        // watcher, but do not report our own save as an outside edit.
-                        watchCurrentFile();
-                        return;
-                    }
-                }
-
-                emit externalChangeDetected(deleted, m_modified);
-            });
-
-    loadOmarchyTheme();
-    watchOmarchyTheme();
-    connect(&m_themeWatcher, &QFileSystemWatcher::fileChanged, this, [this]() {
-        loadOmarchyTheme();
-        watchOmarchyTheme();
-    });
-    connect(&m_themeWatcher, &QFileSystemWatcher::directoryChanged, this, [this]() {
-        loadOmarchyTheme();
-        watchOmarchyTheme();
-    });
+    initializeRuntime();
 }
 
 Backend::Backend(WorkspaceSession *workspaceSession, const QString &windowId, QObject *parent)
@@ -149,8 +114,43 @@ Backend::Backend(WorkspaceSession *workspaceSession, const QString &windowId, QO
         m_modified = buffer.value(QStringLiteral("modified")).toBool();
         break;
     }
+    initializeRuntime();
+}
+
+void Backend::initializeRuntime() {
+    m_wordCountTimer.setSingleShot(true);
+    m_wordCountTimer.setInterval(120);
+    connect(&m_wordCountTimer, &QTimer::timeout, this, &Backend::refreshWordCount);
+    m_recoveryTimer.setSingleShot(true);
+    m_recoveryTimer.setInterval(750);
+    connect(&m_recoveryTimer, &QTimer::timeout, this, &Backend::writeRecovery);
+    connect(&m_fileWatcher, &QFileSystemWatcher::fileChanged, this,
+            [this](const QString &path) {
+                if (path != m_fileUrl.toLocalFile())
+                    return;
+
+                const bool deleted = !QFileInfo::exists(path);
+                if (!deleted && m_hasKnownFileContents) {
+                    QFile file(path);
+                    if (file.open(QIODevice::ReadOnly)
+                            && file.readAll() == m_lastKnownFileContents) {
+                        watchCurrentFile();
+                        return;
+                    }
+                }
+
+                emit externalChangeDetected(deleted, m_modified);
+            });
     loadOmarchyTheme();
     watchOmarchyTheme();
+    connect(&m_themeWatcher, &QFileSystemWatcher::fileChanged, this, [this]() {
+        loadOmarchyTheme();
+        watchOmarchyTheme();
+    });
+    connect(&m_themeWatcher, &QFileSystemWatcher::directoryChanged, this, [this]() {
+        loadOmarchyTheme();
+        watchOmarchyTheme();
+    });
 }
 
 QString Backend::newBuffer() {
@@ -174,6 +174,15 @@ bool Backend::selectBuffer(const QString &id) {
     return true;
 }
 
+bool Backend::moveActiveBuffer(int direction) {
+    if (!m_workspaceSession || !m_workspaceSession->moveActiveTab(m_workspaceWindowId, direction))
+        return false;
+
+    m_workspaceSession->saveNow();
+    emit buffersChanged();
+    return true;
+}
+
 bool Backend::closeActiveBuffer() {
     persistActiveBuffer();
     if (m_modified) {
@@ -194,6 +203,8 @@ bool Backend::discardActiveBuffer() {
         m_bufferSession.saveNow();
     emit buffersChanged();
     emit activeBufferChanged();
+    if (m_workspaceSession && buffers().isEmpty())
+        emit windowEmptied();
     return true;
 }
 
@@ -318,6 +329,14 @@ void Backend::open(const QUrl &url) {
         return;
     }
 
+    if (m_workspaceSession) {
+        const QString openTabId = m_workspaceSession->findOpenLocalFile(url);
+        if (!openTabId.isEmpty()) {
+            emit openTabRequested(openTabId);
+            return;
+        }
+    }
+
     const QString targetName = QFileInfo(url.toLocalFile()).fileName();
     QFile file(url.toLocalFile());
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
@@ -327,11 +346,18 @@ void Backend::open(const QUrl &url) {
 
     const QByteArray contents = file.readAll();
     persistActiveBuffer();
-    m_bufferSession.openBuffer(url, QString::fromUtf8(contents));
+    if (m_workspaceSession)
+        m_workspaceSession->createTab(m_workspaceWindowId, url, QString::fromUtf8(contents),
+                                      0, 0, 0, false);
+    else
+        m_bufferSession.openBuffer(url, QString::fromUtf8(contents));
     loadActiveBuffer();
     m_lastKnownFileContents = contents;
     m_hasKnownFileContents = true;
-    m_bufferSession.saveNow();
+    if (m_workspaceSession)
+        m_workspaceSession->saveNow();
+    else
+        m_bufferSession.saveNow();
     emit buffersChanged();
     emit activeBufferChanged();
     setStatus(QStringLiteral("Opened %1").arg(fileName()));
@@ -414,6 +440,11 @@ void Backend::printDocument() {
 }
 
 void Backend::newWindow() {
+    if (m_workspaceSession) {
+        emit newWindowRequested();
+        return;
+    }
+
     const bool started = QProcess::startDetached(QCoreApplication::applicationFilePath(),
                                                  QStringList());
     if (!started)
@@ -519,6 +550,9 @@ void Backend::openExternalUrl(const QUrl &url) {
 }
 
 QVariantMap Backend::windowGeometry() const {
+    if (m_workspaceSession)
+        return m_workspaceSession->window(m_workspaceWindowId);
+
     QSettings settings;
     return {{QStringLiteral("x"), settings.value(QStringLiteral("window/x"), -1)},
             {QStringLiteral("y"), settings.value(QStringLiteral("window/y"), -1)},
@@ -528,6 +562,13 @@ QVariantMap Backend::windowGeometry() const {
 }
 
 void Backend::saveWindowGeometry(int x, int y, int width, int height, bool maximized) {
+    if (m_workspaceSession) {
+        m_workspaceSession->updateWindowGeometry(m_workspaceWindowId, x, y, width, height,
+                                                  maximized);
+        m_workspaceSession->saveNow();
+        return;
+    }
+
     QSettings settings;
     if (!maximized) {
         settings.setValue(QStringLiteral("window/x"), x);
@@ -570,6 +611,13 @@ void Backend::loadActiveBuffer() {
         setModified(buffer.value(QStringLiteral("modified")).toBool());
         return;
     }
+
+    m_activeBufferText.clear();
+    m_cursorPosition = 0;
+    m_selectionStart = 0;
+    m_selectionEnd = 0;
+    setFileUrl(QUrl());
+    setModified(false);
 }
 
 void Backend::persistActiveBuffer() {
@@ -620,6 +668,15 @@ void Backend::saveTo(const QUrl &url) {
         m_closeAfterSave = false;
         setStatus(QStringLiteral("Only local files can be saved."));
         return;
+    }
+
+    if (m_workspaceSession) {
+        const QString openTabId = m_workspaceSession->findOpenLocalFile(url);
+        if (!openTabId.isEmpty() && openTabId != activeBufferId()) {
+            setStatus(QStringLiteral("This file is already open."));
+            emit openTabRequested(openTabId);
+            return;
+        }
     }
 
     const QString targetName = QFileInfo(url.toLocalFile()).fileName();

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -170,7 +170,18 @@ bool Backend::discardActiveBuffer() {
     return true;
 }
 
+void Backend::prepareForApplicationClose() {
+    if (m_applicationClosing)
+        return;
+
+    persistActiveBuffer();
+    m_applicationClosing = true;
+}
+
 void Backend::updateActiveEditorState(int cursorPosition, int selectionStart, int selectionEnd) {
+    if (m_applicationClosing)
+        return;
+
     m_cursorPosition = cursorPosition;
     m_selectionStart = selectionStart;
     m_selectionEnd = selectionEnd;
@@ -388,7 +399,7 @@ QString Backend::clipboardText() const {
 }
 
 bool Backend::editorTextChanged() {
-    if (m_loading || m_formattingTypography)
+    if (m_applicationClosing || m_loading || m_formattingTypography)
         return false;
 
     const QString text = currentDocumentText();

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -218,6 +218,25 @@ QString Backend::fileName() const {
     return name.isEmpty() ? QStringLiteral("Untitled.md") : name;
 }
 
+QString Backend::bufferTitle(const QVariantMap &buffer, int index) const {
+    const QUrl fileUrl(buffer.value(QStringLiteral("fileUrl")).toString());
+    if (fileUrl.isLocalFile()) {
+        const QString fileName = QFileInfo(fileUrl.toLocalFile()).fileName();
+        if (!fileName.isEmpty())
+            return fileName;
+    }
+
+    const QString firstLine = buffer.value(QStringLiteral("text")).toString()
+        .section(QLatin1Char('\n'), 0, 0).trimmed();
+    if (firstLine.isEmpty())
+        return QStringLiteral("Untitled %1").arg(index + 1);
+
+    constexpr int maximumTitleLength = 29;
+    if (firstLine.size() <= maximumTitleLength)
+        return firstLine;
+    return firstLine.left(maximumTitleLength - 1) + QChar(0x2026);
+}
+
 void Backend::setDarkMode(bool darkMode) {
     if (m_darkMode == darkMode)
         return;
@@ -537,6 +556,7 @@ void Backend::persistActiveBuffer() {
                                  m_activeBufferText, m_cursorPosition, m_selectionStart,
                                  m_selectionEnd, m_modified);
     m_bufferSession.saveNow();
+    emit buffersChanged();
 }
 
 void Backend::setFileUrl(const QUrl &url) {

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -399,6 +399,26 @@ void Backend::discardRecovery() {
 }
 
 void Backend::reloadFromDisk() {
+    if (m_workspaceSession) {
+        QFile file(m_fileUrl.toLocalFile());
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            setStatus(QStringLiteral("Could not reload %1.").arg(fileName()));
+            return;
+        }
+        const QByteArray contents = file.readAll();
+        m_workspaceSession->updateTab(m_workspaceWindowId, activeBufferId(), m_fileUrl,
+                                      QString::fromUtf8(contents), 0, 0, 0, false);
+        m_workspaceSession->setExternalChange(activeBufferId(), false);
+        m_workspaceSession->saveNow();
+        m_lastKnownFileContents = contents;
+        m_hasKnownFileContents = true;
+        loadActiveBuffer();
+        emit buffersChanged();
+        emit activeBufferChanged();
+        setStatus(QStringLiteral("Reloaded %1").arg(fileName()));
+        return;
+    }
+
     if (m_fileUrl.isLocalFile())
         open(m_fileUrl);
 }
@@ -413,9 +433,20 @@ void Backend::keepExternalVersion() {
         m_hasKnownFileContents = false;
     }
     setModified(true);
+    if (m_workspaceSession)
+        m_workspaceSession->setExternalChange(activeBufferId(), false);
     persistActiveBuffer();
     watchCurrentFile();
     setStatus(QStringLiteral("Kept your version"));
+}
+
+void Backend::reportExternalChange(bool deleted) {
+    emit buffersChanged();
+    emit externalChangeDetected(deleted, m_modified);
+}
+
+void Backend::refreshBuffers() {
+    emit buffersChanged();
 }
 
 void Backend::printDocument() {
@@ -775,6 +806,9 @@ void Backend::clearRecovery() {
 }
 
 void Backend::watchCurrentFile() {
+    if (m_workspaceSession)
+        return;
+
     const QStringList watched = m_fileWatcher.files();
     if (!watched.isEmpty())
         m_fileWatcher.removePaths(watched);

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -157,6 +157,10 @@ bool Backend::closeActiveBuffer() {
         setStatus(QStringLiteral("Save or discard changes before closing this tab"));
         return false;
     }
+    return discardActiveBuffer();
+}
+
+bool Backend::discardActiveBuffer() {
     if (!m_bufferSession.closeBuffer(m_bufferSession.activeBufferId()))
         return false;
     loadActiveBuffer();

--- a/src/backend.h
+++ b/src/backend.h
@@ -22,6 +22,9 @@ class Backend : public QObject {
     Q_PROPERTY(QUrl fileUrl READ fileUrl NOTIFY fileUrlChanged)
     Q_PROPERTY(QVariantList buffers READ buffers NOTIFY buffersChanged)
     Q_PROPERTY(QString activeBufferId READ activeBufferId NOTIFY activeBufferChanged)
+    Q_PROPERTY(int activeCursorPosition READ activeCursorPosition NOTIFY activeBufferChanged)
+    Q_PROPERTY(int activeSelectionStart READ activeSelectionStart NOTIFY activeBufferChanged)
+    Q_PROPERTY(int activeSelectionEnd READ activeSelectionEnd NOTIFY activeBufferChanged)
     Q_PROPERTY(QString fileName READ fileName NOTIFY fileUrlChanged)
     Q_PROPERTY(bool modified READ modified NOTIFY modifiedChanged)
     Q_PROPERTY(QString status READ status NOTIFY statusChanged)
@@ -42,6 +45,9 @@ public:
     QUrl fileUrl() const { return m_fileUrl; }
     QVariantList buffers() const { return m_bufferSession.buffers(); }
     QString activeBufferId() const { return m_bufferSession.activeBufferId(); }
+    int activeCursorPosition() const { return m_cursorPosition; }
+    int activeSelectionStart() const { return m_selectionStart; }
+    int activeSelectionEnd() const { return m_selectionEnd; }
     QString fileName() const;
 
     bool modified() const { return m_modified; }

--- a/src/backend.h
+++ b/src/backend.h
@@ -79,6 +79,7 @@ public:
     Q_INVOKABLE void attachDocument(QObject *textDocument);
     Q_INVOKABLE QString newBuffer();
     Q_INVOKABLE bool selectBuffer(const QString &id);
+    Q_INVOKABLE bool moveActiveBuffer(int direction);
     Q_INVOKABLE bool closeActiveBuffer();
     Q_INVOKABLE bool discardActiveBuffer();
     Q_INVOKABLE void prepareForApplicationClose();
@@ -120,8 +121,12 @@ signals:
     void saveDialogRequested(const QUrl &suggestedUrl);
     void saveSucceeded();
     void externalChangeDetected(bool deleted, bool locallyModified);
+    void newWindowRequested();
+    void openTabRequested(const QString &tabId);
+    void windowEmptied();
 
 private:
+    void initializeRuntime();
     void loadDocumentText(const QString &text);
     void loadActiveBuffer();
     void persistActiveBuffer();

--- a/src/backend.h
+++ b/src/backend.h
@@ -54,6 +54,7 @@ public:
     QString activeBufferText() const { return m_activeBufferText; }
     bool restoringActiveBuffer() const { return m_restoringActiveBuffer; }
     QString fileName() const;
+    Q_INVOKABLE QString bufferTitle(const QVariantMap &buffer, int index) const;
 
     bool modified() const { return m_modified; }
     QString status() const { return m_status; }

--- a/src/backend.h
+++ b/src/backend.h
@@ -103,6 +103,8 @@ public:
     Q_INVOKABLE QVariantList hiddenRangesAt(int position) const;
     Q_INVOKABLE void setSearchHighlight(const QString &query, int currentMatchStart);
     Q_INVOKABLE void openExternalUrl(const QUrl &url);
+    void reportExternalChange(bool deleted);
+    void refreshBuffers();
     Q_INVOKABLE QVariantMap windowGeometry() const;
     Q_INVOKABLE void saveWindowGeometry(int x, int y, int width, int height, bool maximized);
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -63,6 +63,7 @@ public:
     Q_INVOKABLE QString newBuffer();
     Q_INVOKABLE bool selectBuffer(const QString &id);
     Q_INVOKABLE bool closeActiveBuffer();
+    Q_INVOKABLE bool discardActiveBuffer();
     Q_INVOKABLE void updateActiveEditorState(int cursorPosition, int selectionStart, int selectionEnd);
     Q_INVOKABLE void openDialog();
     Q_INVOKABLE void open(const QUrl &url);

--- a/src/backend.h
+++ b/src/backend.h
@@ -25,6 +25,8 @@ class Backend : public QObject {
     Q_PROPERTY(int activeCursorPosition READ activeCursorPosition NOTIFY activeBufferChanged)
     Q_PROPERTY(int activeSelectionStart READ activeSelectionStart NOTIFY activeBufferChanged)
     Q_PROPERTY(int activeSelectionEnd READ activeSelectionEnd NOTIFY activeBufferChanged)
+    Q_PROPERTY(QString activeBufferText READ activeBufferText NOTIFY activeBufferChanged)
+    Q_PROPERTY(bool restoringActiveBuffer READ restoringActiveBuffer NOTIFY activeBufferChanged)
     Q_PROPERTY(QString fileName READ fileName NOTIFY fileUrlChanged)
     Q_PROPERTY(bool modified READ modified NOTIFY modifiedChanged)
     Q_PROPERTY(QString status READ status NOTIFY statusChanged)
@@ -38,6 +40,7 @@ class Backend : public QObject {
 
 public:
     explicit Backend(QObject *parent = nullptr);
+    Backend(const QString &stateDirectory, QObject *parent = nullptr);
     ~Backend() override;
 
     void setParentWindow(QWindow *window);
@@ -48,6 +51,8 @@ public:
     int activeCursorPosition() const { return m_cursorPosition; }
     int activeSelectionStart() const { return m_selectionStart; }
     int activeSelectionEnd() const { return m_selectionEnd; }
+    QString activeBufferText() const { return m_activeBufferText; }
+    bool restoringActiveBuffer() const { return m_restoringActiveBuffer; }
     QString fileName() const;
 
     bool modified() const { return m_modified; }
@@ -71,6 +76,7 @@ public:
     Q_INVOKABLE bool closeActiveBuffer();
     Q_INVOKABLE bool discardActiveBuffer();
     Q_INVOKABLE void prepareForApplicationClose();
+    Q_INVOKABLE void finishActiveBufferRestore();
     Q_INVOKABLE void updateActiveEditorState(int cursorPosition, int selectionStart, int selectionEnd);
     Q_INVOKABLE void openDialog();
     Q_INVOKABLE void open(const QUrl &url);
@@ -148,6 +154,7 @@ private:
     int m_cursorPosition = 0;
     int m_selectionStart = 0;
     int m_selectionEnd = 0;
+    QString m_activeBufferText;
     QTimer m_wordCountTimer;
     QTimer m_recoveryTimer;
     QFileSystemWatcher m_fileWatcher;
@@ -159,6 +166,8 @@ private:
     QByteArray m_lastKnownFileContents;
     bool m_hasKnownFileContents = false;
     bool m_applicationClosing = false;
+    bool m_restoringActiveBuffer = false;
+    bool m_ignoringInitialCursorReset = false;
     QString m_recoveryPath;
     std::unique_ptr<QLockFile> m_recoveryLock;
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -10,6 +10,8 @@
 #include <QVariantList>
 #include <memory>
 
+#include "buffersession.h"
+
 class MarkdownHighlighter;
 class QTextDocument;
 class QWindow;
@@ -18,6 +20,8 @@ class QLockFile;
 class Backend : public QObject {
     Q_OBJECT
     Q_PROPERTY(QUrl fileUrl READ fileUrl NOTIFY fileUrlChanged)
+    Q_PROPERTY(QVariantList buffers READ buffers NOTIFY buffersChanged)
+    Q_PROPERTY(QString activeBufferId READ activeBufferId NOTIFY activeBufferChanged)
     Q_PROPERTY(QString fileName READ fileName NOTIFY fileUrlChanged)
     Q_PROPERTY(bool modified READ modified NOTIFY modifiedChanged)
     Q_PROPERTY(QString status READ status NOTIFY statusChanged)
@@ -36,6 +40,8 @@ public:
     void setParentWindow(QWindow *window);
 
     QUrl fileUrl() const { return m_fileUrl; }
+    QVariantList buffers() const { return m_bufferSession.buffers(); }
+    QString activeBufferId() const { return m_bufferSession.activeBufferId(); }
     QString fileName() const;
 
     bool modified() const { return m_modified; }
@@ -54,6 +60,10 @@ public:
     static QString suggestedFileName(const QString &text);
 
     Q_INVOKABLE void attachDocument(QObject *textDocument);
+    Q_INVOKABLE QString newBuffer();
+    Q_INVOKABLE bool selectBuffer(const QString &id);
+    Q_INVOKABLE bool closeActiveBuffer();
+    Q_INVOKABLE void updateActiveEditorState(int cursorPosition, int selectionStart, int selectionEnd);
     Q_INVOKABLE void openDialog();
     Q_INVOKABLE void open(const QUrl &url);
     Q_INVOKABLE void save();
@@ -77,6 +87,8 @@ public:
 
 signals:
     void fileUrlChanged();
+    void buffersChanged();
+    void activeBufferChanged();
     void modifiedChanged();
     void statusChanged();
     void wordCountChanged();
@@ -91,6 +103,8 @@ signals:
 
 private:
     void loadDocumentText(const QString &text);
+    void loadActiveBuffer();
+    void persistActiveBuffer();
     void setFileUrl(const QUrl &url);
     void setModified(bool modified);
     void setStatus(const QString &status);
@@ -123,9 +137,13 @@ private:
     int m_formattedBlockCount = 0;
     int m_lastChangePos = 0;
     int m_lastChangeAdded = 0;
+    int m_cursorPosition = 0;
+    int m_selectionStart = 0;
+    int m_selectionEnd = 0;
     QTimer m_wordCountTimer;
     QTimer m_recoveryTimer;
     QFileSystemWatcher m_fileWatcher;
+    BufferSession m_bufferSession;
     QPointer<QTextDocument> m_document;
     QPointer<QWindow> m_parentWindow;
     QPointer<MarkdownHighlighter> m_highlighter;

--- a/src/backend.h
+++ b/src/backend.h
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include "buffersession.h"
+#include "workspacesession.h"
 
 class MarkdownHighlighter;
 class QTextDocument;
@@ -41,13 +42,17 @@ class Backend : public QObject {
 public:
     explicit Backend(QObject *parent = nullptr);
     Backend(const QString &stateDirectory, QObject *parent = nullptr);
+    Backend(WorkspaceSession *workspaceSession, const QString &windowId,
+            QObject *parent = nullptr);
     ~Backend() override;
 
     void setParentWindow(QWindow *window);
 
     QUrl fileUrl() const { return m_fileUrl; }
-    QVariantList buffers() const { return m_bufferSession.buffers(); }
-    QString activeBufferId() const { return m_bufferSession.activeBufferId(); }
+    QVariantList buffers() const { return m_workspaceSession
+            ? m_workspaceSession->tabs(m_workspaceWindowId) : m_bufferSession.buffers(); }
+    QString activeBufferId() const { return m_workspaceSession
+            ? m_workspaceSession->activeTabId(m_workspaceWindowId) : m_bufferSession.activeBufferId(); }
     int activeCursorPosition() const { return m_cursorPosition; }
     int activeSelectionStart() const { return m_selectionStart; }
     int activeSelectionEnd() const { return m_selectionEnd; }
@@ -160,6 +165,8 @@ private:
     QTimer m_recoveryTimer;
     QFileSystemWatcher m_fileWatcher;
     BufferSession m_bufferSession;
+    WorkspaceSession *m_workspaceSession = nullptr;
+    QString m_workspaceWindowId;
     QPointer<QTextDocument> m_document;
     QPointer<QWindow> m_parentWindow;
     QPointer<MarkdownHighlighter> m_highlighter;

--- a/src/backend.h
+++ b/src/backend.h
@@ -70,6 +70,7 @@ public:
     Q_INVOKABLE bool selectBuffer(const QString &id);
     Q_INVOKABLE bool closeActiveBuffer();
     Q_INVOKABLE bool discardActiveBuffer();
+    Q_INVOKABLE void prepareForApplicationClose();
     Q_INVOKABLE void updateActiveEditorState(int cursorPosition, int selectionStart, int selectionEnd);
     Q_INVOKABLE void openDialog();
     Q_INVOKABLE void open(const QUrl &url);
@@ -157,6 +158,7 @@ private:
     QString m_lastDocumentText;
     QByteArray m_lastKnownFileContents;
     bool m_hasKnownFileContents = false;
+    bool m_applicationClosing = false;
     QString m_recoveryPath;
     std::unique_ptr<QLockFile> m_recoveryLock;
 

--- a/src/buffersession.cpp
+++ b/src/buffersession.cpp
@@ -99,6 +99,23 @@ bool BufferSession::selectBuffer(const QString &id) {
     return false;
 }
 
+bool BufferSession::closeBuffer(const QString &id) {
+    for (int index = 0; index < m_buffers.size(); ++index) {
+        if (m_buffers.at(index).toMap().value(QStringLiteral("id")).toString() != id)
+            continue;
+        m_buffers.removeAt(index);
+        if (m_buffers.isEmpty()) {
+            createBuffer();
+            return true;
+        }
+        if (m_activeBufferId == id)
+            m_activeBufferId = m_buffers.at(qMin(index, m_buffers.size() - 1)).toMap()
+                .value(QStringLiteral("id")).toString();
+        return true;
+    }
+    return false;
+}
+
 bool BufferSession::updateBuffer(const QString &id, const QString &fileUrl, const QString &text,
                                  int cursorPosition, int selectionStart, int selectionEnd,
                                  bool modified) {

--- a/src/buffersession.cpp
+++ b/src/buffersession.cpp
@@ -1,0 +1,176 @@
+#include "buffersession.h"
+
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QSaveFile>
+#include <QUuid>
+
+namespace {
+constexpr int sessionVersion = 1;
+
+QJsonObject jsonBuffer(const QVariantMap &buffer) {
+    return {{QStringLiteral("id"), buffer.value(QStringLiteral("id")).toString()},
+            {QStringLiteral("fileUrl"), buffer.value(QStringLiteral("fileUrl")).toString()},
+            {QStringLiteral("text"), buffer.value(QStringLiteral("text")).toString()},
+            {QStringLiteral("cursorPosition"), buffer.value(QStringLiteral("cursorPosition")).toInt()},
+            {QStringLiteral("selectionStart"), buffer.value(QStringLiteral("selectionStart")).toInt()},
+            {QStringLiteral("selectionEnd"), buffer.value(QStringLiteral("selectionEnd")).toInt()},
+            {QStringLiteral("modified"), buffer.value(QStringLiteral("modified")).toBool()}};
+}
+
+bool bufferFromJson(const QJsonValue &value, QVariantMap *buffer) {
+    if (!value.isObject())
+        return false;
+
+    const QJsonObject object = value.toObject();
+    const QJsonValue id = object.value(QStringLiteral("id"));
+    const QJsonValue fileUrl = object.value(QStringLiteral("fileUrl"));
+    const QJsonValue text = object.value(QStringLiteral("text"));
+    const QJsonValue cursorPosition = object.value(QStringLiteral("cursorPosition"));
+    const QJsonValue selectionStart = object.value(QStringLiteral("selectionStart"));
+    const QJsonValue selectionEnd = object.value(QStringLiteral("selectionEnd"));
+    const QJsonValue modified = object.value(QStringLiteral("modified"));
+    if (!id.isString() || id.toString().isEmpty() || !fileUrl.isString() || !text.isString()
+            || !cursorPosition.isDouble() || !selectionStart.isDouble() || !selectionEnd.isDouble()
+            || !modified.isBool())
+        return false;
+
+    const int textLength = text.toString().size();
+    *buffer = {{QStringLiteral("id"), id.toString()},
+               {QStringLiteral("fileUrl"), fileUrl.toString()},
+               {QStringLiteral("text"), text.toString()},
+               {QStringLiteral("cursorPosition"), qBound(0, cursorPosition.toInt(), textLength)},
+               {QStringLiteral("selectionStart"), qBound(0, selectionStart.toInt(), textLength)},
+               {QStringLiteral("selectionEnd"), qBound(0, selectionEnd.toInt(), textLength)},
+               {QStringLiteral("modified"), modified.toBool()}};
+    return true;
+}
+}
+
+BufferSession::BufferSession(const QString &stateDirectory) : m_stateDirectory(stateDirectory) {}
+
+QVariantList BufferSession::buffers() const {
+    return m_buffers;
+}
+
+QString BufferSession::activeBufferId() const {
+    return m_activeBufferId;
+}
+
+QString BufferSession::createBuffer() {
+    const QString id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    m_buffers.append(QVariantMap{{QStringLiteral("id"), id},
+                                 {QStringLiteral("fileUrl"), QString()},
+                                 {QStringLiteral("text"), QString()},
+                                 {QStringLiteral("cursorPosition"), 0},
+                                 {QStringLiteral("selectionStart"), 0},
+                                 {QStringLiteral("selectionEnd"), 0},
+                                 {QStringLiteral("modified"), false}});
+    m_activeBufferId = id;
+    return id;
+}
+
+QString BufferSession::openBuffer(const QUrl &fileUrl, const QString &text) {
+    const QString url = fileUrl.toString();
+    for (const QVariant &value : m_buffers) {
+        const QVariantMap buffer = value.toMap();
+        if (buffer.value(QStringLiteral("fileUrl")).toString() == url) {
+            m_activeBufferId = buffer.value(QStringLiteral("id")).toString();
+            return m_activeBufferId;
+        }
+    }
+
+    const QString id = createBuffer();
+    updateBuffer(id, url, text, 0, 0, 0, false);
+    return id;
+}
+
+bool BufferSession::selectBuffer(const QString &id) {
+    for (const QVariant &value : m_buffers) {
+        if (value.toMap().value(QStringLiteral("id")).toString() == id) {
+            m_activeBufferId = id;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool BufferSession::updateBuffer(const QString &id, const QString &fileUrl, const QString &text,
+                                 int cursorPosition, int selectionStart, int selectionEnd,
+                                 bool modified) {
+    for (QVariant &value : m_buffers) {
+        QVariantMap buffer = value.toMap();
+        if (buffer.value(QStringLiteral("id")).toString() != id)
+            continue;
+
+        buffer.insert(QStringLiteral("fileUrl"), fileUrl);
+        buffer.insert(QStringLiteral("text"), text);
+        buffer.insert(QStringLiteral("cursorPosition"), qBound(0, cursorPosition, text.size()));
+        buffer.insert(QStringLiteral("selectionStart"), qBound(0, selectionStart, text.size()));
+        buffer.insert(QStringLiteral("selectionEnd"), qBound(0, selectionEnd, text.size()));
+        buffer.insert(QStringLiteral("modified"), modified);
+        value = buffer;
+        return true;
+    }
+    return false;
+}
+
+bool BufferSession::restore() {
+    QFile file(sessionPath());
+    if (!file.open(QIODevice::ReadOnly))
+        return false;
+
+    const QJsonDocument document = QJsonDocument::fromJson(file.readAll());
+    if (!document.isObject())
+        return false;
+
+    const QJsonObject root = document.object();
+    if (root.value(QStringLiteral("version")).toInt() != sessionVersion
+            || !root.value(QStringLiteral("activeBufferId")).isString()
+            || !root.value(QStringLiteral("buffers")).isArray())
+        return false;
+
+    QVariantList restoredBuffers;
+    QSet<QString> identifiers;
+    for (const QJsonValue &value : root.value(QStringLiteral("buffers")).toArray()) {
+        QVariantMap buffer;
+        if (!bufferFromJson(value, &buffer) || identifiers.contains(buffer.value(QStringLiteral("id")).toString()))
+            return false;
+        identifiers.insert(buffer.value(QStringLiteral("id")).toString());
+        restoredBuffers.append(buffer);
+    }
+    const QString activeBufferId = root.value(QStringLiteral("activeBufferId")).toString();
+    if (restoredBuffers.isEmpty() || !identifiers.contains(activeBufferId))
+        return false;
+
+    m_buffers = restoredBuffers;
+    m_activeBufferId = activeBufferId;
+    return true;
+}
+
+bool BufferSession::saveNow() const {
+    if (m_buffers.isEmpty() || m_activeBufferId.isEmpty())
+        return false;
+
+    QDir().mkpath(m_stateDirectory);
+    QSaveFile file(sessionPath());
+    if (!file.open(QIODevice::WriteOnly))
+        return false;
+
+    QJsonArray buffers;
+    for (const QVariant &value : m_buffers)
+        buffers.append(jsonBuffer(value.toMap()));
+    file.write(QJsonDocument(QJsonObject{{QStringLiteral("version"), sessionVersion},
+                                         {QStringLiteral("activeBufferId"), m_activeBufferId},
+                                         {QStringLiteral("buffers"), buffers}})
+                   .toJson(QJsonDocument::Compact));
+    return file.commit();
+}
+
+QString BufferSession::sessionPath() const {
+    return QDir(m_stateDirectory).filePath(QStringLiteral("session.json"));
+}

--- a/src/buffersession.cpp
+++ b/src/buffersession.cpp
@@ -136,6 +136,23 @@ bool BufferSession::updateBuffer(const QString &id, const QString &fileUrl, cons
     return false;
 }
 
+bool BufferSession::updateBufferCursor(const QString &id, int cursorPosition, int selectionStart,
+                                       int selectionEnd) {
+    for (QVariant &value : m_buffers) {
+        QVariantMap buffer = value.toMap();
+        if (buffer.value(QStringLiteral("id")).toString() != id)
+            continue;
+
+        const int textLength = buffer.value(QStringLiteral("text")).toString().size();
+        buffer.insert(QStringLiteral("cursorPosition"), qBound(0, cursorPosition, textLength));
+        buffer.insert(QStringLiteral("selectionStart"), qBound(0, selectionStart, textLength));
+        buffer.insert(QStringLiteral("selectionEnd"), qBound(0, selectionEnd, textLength));
+        value = buffer;
+        return true;
+    }
+    return false;
+}
+
 bool BufferSession::restore() {
     QFile file(sessionPath());
     if (!file.open(QIODevice::ReadOnly))

--- a/src/buffersession.h
+++ b/src/buffersession.h
@@ -13,6 +13,7 @@ public:
     QString createBuffer();
     QString openBuffer(const QUrl &fileUrl, const QString &text);
     bool selectBuffer(const QString &id);
+    bool closeBuffer(const QString &id);
     bool updateBuffer(const QString &id, const QString &fileUrl, const QString &text,
                       int cursorPosition, int selectionStart, int selectionEnd, bool modified);
     bool restore();

--- a/src/buffersession.h
+++ b/src/buffersession.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QString>
+#include <QUrl>
+#include <QVariantList>
+
+class BufferSession {
+public:
+    explicit BufferSession(const QString &stateDirectory);
+
+    QVariantList buffers() const;
+    QString activeBufferId() const;
+    QString createBuffer();
+    QString openBuffer(const QUrl &fileUrl, const QString &text);
+    bool selectBuffer(const QString &id);
+    bool updateBuffer(const QString &id, const QString &fileUrl, const QString &text,
+                      int cursorPosition, int selectionStart, int selectionEnd, bool modified);
+    bool restore();
+    bool saveNow() const;
+
+private:
+    QString sessionPath() const;
+
+    QString m_stateDirectory;
+    QVariantList m_buffers;
+    QString m_activeBufferId;
+};

--- a/src/buffersession.h
+++ b/src/buffersession.h
@@ -16,6 +16,8 @@ public:
     bool closeBuffer(const QString &id);
     bool updateBuffer(const QString &id, const QString &fileUrl, const QString &text,
                       int cursorPosition, int selectionStart, int selectionEnd, bool modified);
+    bool updateBufferCursor(const QString &id, int cursorPosition, int selectionStart,
+                            int selectionEnd);
     bool restore();
     bool saveNow() const;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,7 @@ int main(int argc, char *argv[]) {
                     << QFile::exists(QStringLiteral(":/Main.qml"));
         return -1;
     }
+    windows.recoverLegacySnapshots();
 
     const QStringList args = app.arguments();
     if (args.size() > 1 && !windows.primaryBackend()->modified())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,12 +6,15 @@
 #include <QQmlContext>
 #include <QQmlError>
 #include <QQuickStyle>
+#include <QStandardPaths>
 #include <QUrl>
 #include <QWindow>
 #include <QFile>
 
 #include "backend.h"
 #include "systemtheme.h"
+#include "windowmanager.h"
+#include "workspacesession.h"
 
 int main(int argc, char *argv[]) {
     QApplication app(argc, argv);
@@ -28,11 +31,7 @@ int main(int argc, char *argv[]) {
 
     QQuickStyle::setStyle(QStringLiteral("Material"));
 
-    Backend backend(&app);
     SystemTheme systemTheme(&app);
-    backend.setDarkMode(systemTheme.darkMode());
-    QObject::connect(&systemTheme, &SystemTheme::darkModeChanged, &backend,
-                     &Backend::setDarkMode);
 
     // Carry the desktop's text scale into the default font, so the chrome that
     // inherits it (dialog titles, buttons) grows along with the writing area.
@@ -47,33 +46,37 @@ int main(int argc, char *argv[]) {
     };
     applyInterfaceFont(systemTheme.textScale());
 
-    backend.setTextScale(systemTheme.textScale());
-    QObject::connect(&systemTheme, &SystemTheme::textScaleChanged, &backend,
-                     [&backend, applyInterfaceFont](qreal textScale) {
-        applyInterfaceFont(textScale);
-        backend.setTextScale(textScale);
-    });
-
     QQmlApplicationEngine engine;
     QObject::connect(&engine, &QQmlApplicationEngine::warnings, &app,
                      [](const QList<QQmlError> &warnings) {
         for (const QQmlError &warning : warnings)
             qWarning().noquote() << warning.toString();
     });
-    engine.rootContext()->setContextProperty(QStringLiteral("backend"), &backend);
+    WorkspaceSession workspaceSession(
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+    workspaceSession.restore();
+    WindowManager windows(&workspaceSession, &engine, QUrl(QStringLiteral("qrc:/Main.qml")));
+    windows.setDarkMode(systemTheme.darkMode());
+    windows.setTextScale(systemTheme.textScale());
+    QObject::connect(&systemTheme, &SystemTheme::darkModeChanged, &windows,
+                     &WindowManager::setDarkMode);
+    QObject::connect(&systemTheme, &SystemTheme::textScaleChanged, &windows,
+                     [&windows, applyInterfaceFont](qreal textScale) {
+        applyInterfaceFont(textScale);
+        windows.setTextScale(textScale);
+    });
 
-    engine.load(QUrl(QStringLiteral("qrc:/Main.qml")));
-    if (engine.rootObjects().isEmpty()) {
+    if (windows.restoreWindows() == 0)
+        windows.createWindow();
+    if (!windows.primaryBackend()) {
         qCritical() << "Could not load the Omawrite interface; resource available:"
                     << QFile::exists(QStringLiteral(":/Main.qml"));
         return -1;
     }
 
-    backend.setParentWindow(qobject_cast<QWindow *>(engine.rootObjects().constFirst()));
-
     const QStringList args = app.arguments();
-    if (args.size() > 1 && !backend.modified())
-        backend.open(QUrl::fromLocalFile(args.at(1)));
+    if (args.size() > 1 && !windows.primaryBackend()->modified())
+        windows.primaryBackend()->open(QUrl::fromLocalFile(args.at(1)));
 
     return app.exec();
 }

--- a/src/windowmanager.cpp
+++ b/src/windowmanager.cpp
@@ -5,6 +5,9 @@
 #include <QQmlEngine>
 #include <QFile>
 #include <QFileInfo>
+#include <QDir>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QTimer>
 #include <QWindow>
 
@@ -49,6 +52,34 @@ int WindowManager::restoreWindows() {
             return 0;
     }
     return m_windows.size();
+}
+
+int WindowManager::recoverLegacySnapshots() {
+    if (!m_workspaceSession || m_windows.isEmpty())
+        return 0;
+
+    int recovered = 0;
+    const QString windowId = m_windows.constFirst().id;
+    const QStringList snapshots = QDir(m_workspaceSession->stateDirectory())
+        .entryList({QStringLiteral("recovery-*.json")}, QDir::Files, QDir::Name);
+    for (const QString &snapshot : snapshots) {
+        QFile file(QDir(m_workspaceSession->stateDirectory()).filePath(snapshot));
+        if (!file.open(QIODevice::ReadOnly))
+            continue;
+        const QJsonDocument document = QJsonDocument::fromJson(file.readAll());
+        if (!document.isObject() || !document.object().value(QStringLiteral("text")).isString())
+            continue;
+        if (m_workspaceSession->createTab(windowId, QUrl(),
+                                          document.object().value(QStringLiteral("text")).toString(),
+                                          0, 0, 0, true).isEmpty())
+            continue;
+        file.close();
+        QFile::remove(file.fileName());
+        ++recovered;
+    }
+    if (recovered > 0)
+        m_workspaceSession->saveNow();
+    return recovered;
 }
 
 Backend *WindowManager::createWindow(const QString &windowId) {

--- a/src/windowmanager.cpp
+++ b/src/windowmanager.cpp
@@ -3,6 +3,7 @@
 #include <QQmlComponent>
 #include <QQmlContext>
 #include <QQmlEngine>
+#include <QTimer>
 #include <QWindow>
 
 #include "backend.h"
@@ -50,6 +51,8 @@ Backend *WindowManager::createWindow(const QString &windowId) {
         return nullptr;
 
     auto *backend = new Backend(m_workspaceSession, windowId);
+    backend->setDarkMode(m_darkMode);
+    backend->setTextScale(m_textScale);
     auto *context = new QQmlContext(m_engine->rootContext());
     context->setContextProperty(QStringLiteral("backend"), backend);
     QQmlComponent component(m_engine, m_qmlUrl, backend);
@@ -60,10 +63,61 @@ Backend *WindowManager::createWindow(const QString &windowId) {
         return nullptr;
     }
     backend->setParentWindow(qobject_cast<QWindow *>(window));
-    m_windows.append({backend, context, window});
+    connect(backend, &Backend::newWindowRequested, this, [this]() { createWindow(); });
+    connect(backend, &Backend::openTabRequested, this, &WindowManager::activateTab);
+    connect(backend, &Backend::windowEmptied, this, [this, windowId]() {
+        QTimer::singleShot(0, this, [this, windowId]() { closeWindow(windowId); });
+    });
+    m_windows.append({windowId, backend, context, window});
     return backend;
 }
 
 int WindowManager::windowCount() const {
     return m_windows.size();
+}
+
+Backend *WindowManager::primaryBackend() const {
+    return m_windows.isEmpty() ? nullptr : m_windows.constFirst().backend;
+}
+
+void WindowManager::setDarkMode(bool darkMode) {
+    m_darkMode = darkMode;
+    for (const WritingWindow &window : m_windows)
+        window.backend->setDarkMode(darkMode);
+}
+
+void WindowManager::setTextScale(qreal textScale) {
+    m_textScale = textScale;
+    for (const WritingWindow &window : m_windows)
+        window.backend->setTextScale(textScale);
+}
+
+void WindowManager::activateTab(const QString &tabId) {
+    const QString windowId = m_workspaceSession->windowIdForTab(tabId);
+    for (const WritingWindow &window : m_windows) {
+        if (window.id != windowId)
+            continue;
+        window.backend->selectBuffer(tabId);
+        auto *nativeWindow = qobject_cast<QWindow *>(window.root);
+        if (nativeWindow) {
+            nativeWindow->raise();
+            nativeWindow->requestActivate();
+        }
+        return;
+    }
+}
+
+void WindowManager::closeWindow(const QString &windowId) {
+    for (int index = 0; index < m_windows.size(); ++index) {
+        WritingWindow window = m_windows.at(index);
+        if (window.id != windowId)
+            continue;
+        m_windows.removeAt(index);
+        m_workspaceSession->removeWindow(window.id);
+        m_workspaceSession->saveNow();
+        window.root->deleteLater();
+        window.context->deleteLater();
+        window.backend->deleteLater();
+        return;
+    }
 }

--- a/src/windowmanager.cpp
+++ b/src/windowmanager.cpp
@@ -26,6 +26,28 @@ Backend *WindowManager::createWindow() {
 
     const QString windowId = m_workspaceSession->createWindow(-1, -1, 1280, 820, false);
     m_workspaceSession->createTab(windowId, QUrl(), QString(), 0, 0, 0, false);
+    Backend *backend = createWindow(windowId);
+    if (!backend)
+        return nullptr;
+
+    m_workspaceSession->saveNow();
+    return backend;
+}
+
+int WindowManager::restoreWindows() {
+    if (!m_workspaceSession || !m_engine)
+        return 0;
+
+    for (const QVariant &value : m_workspaceSession->windows()) {
+        if (!createWindow(value.toMap().value(QStringLiteral("id")).toString()))
+            return 0;
+    }
+    return m_windows.size();
+}
+
+Backend *WindowManager::createWindow(const QString &windowId) {
+    if (windowId.isEmpty())
+        return nullptr;
 
     auto *backend = new Backend(m_workspaceSession, windowId);
     auto *context = new QQmlContext(m_engine->rootContext());
@@ -39,7 +61,6 @@ Backend *WindowManager::createWindow() {
     }
     backend->setParentWindow(qobject_cast<QWindow *>(window));
     m_windows.append({backend, context, window});
-    m_workspaceSession->saveNow();
     return backend;
 }
 

--- a/src/windowmanager.cpp
+++ b/src/windowmanager.cpp
@@ -1,0 +1,48 @@
+#include "windowmanager.h"
+
+#include <QQmlComponent>
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <QWindow>
+
+#include "backend.h"
+#include "workspacesession.h"
+
+WindowManager::WindowManager(WorkspaceSession *workspaceSession, QQmlEngine *engine,
+                             const QUrl &qmlUrl, QObject *parent)
+    : QObject(parent), m_workspaceSession(workspaceSession), m_engine(engine), m_qmlUrl(qmlUrl) {}
+
+WindowManager::~WindowManager() {
+    for (const WritingWindow &window : m_windows) {
+        delete window.root;
+        delete window.context;
+        delete window.backend;
+    }
+}
+
+Backend *WindowManager::createWindow() {
+    if (!m_workspaceSession || !m_engine)
+        return nullptr;
+
+    const QString windowId = m_workspaceSession->createWindow(-1, -1, 1280, 820, false);
+    m_workspaceSession->createTab(windowId, QUrl(), QString(), 0, 0, 0, false);
+
+    auto *backend = new Backend(m_workspaceSession, windowId);
+    auto *context = new QQmlContext(m_engine->rootContext());
+    context->setContextProperty(QStringLiteral("backend"), backend);
+    QQmlComponent component(m_engine, m_qmlUrl, backend);
+    QObject *window = component.create(context);
+    if (!window) {
+        delete context;
+        delete backend;
+        return nullptr;
+    }
+    backend->setParentWindow(qobject_cast<QWindow *>(window));
+    m_windows.append({backend, context, window});
+    m_workspaceSession->saveNow();
+    return backend;
+}
+
+int WindowManager::windowCount() const {
+    return m_windows.size();
+}

--- a/src/windowmanager.cpp
+++ b/src/windowmanager.cpp
@@ -3,6 +3,8 @@
 #include <QQmlComponent>
 #include <QQmlContext>
 #include <QQmlEngine>
+#include <QFile>
+#include <QFileInfo>
 #include <QTimer>
 #include <QWindow>
 
@@ -11,7 +13,10 @@
 
 WindowManager::WindowManager(WorkspaceSession *workspaceSession, QQmlEngine *engine,
                              const QUrl &qmlUrl, QObject *parent)
-    : QObject(parent), m_workspaceSession(workspaceSession), m_engine(engine), m_qmlUrl(qmlUrl) {}
+    : QObject(parent), m_workspaceSession(workspaceSession), m_engine(engine), m_qmlUrl(qmlUrl) {
+    connect(&m_fileWatcher, &QFileSystemWatcher::fileChanged, this,
+            &WindowManager::handleFileChange);
+}
 
 WindowManager::~WindowManager() {
     for (const WritingWindow &window : m_windows) {
@@ -65,10 +70,18 @@ Backend *WindowManager::createWindow(const QString &windowId) {
     backend->setParentWindow(qobject_cast<QWindow *>(window));
     connect(backend, &Backend::newWindowRequested, this, [this]() { createWindow(); });
     connect(backend, &Backend::openTabRequested, this, &WindowManager::activateTab);
+    connect(backend, &Backend::activeBufferChanged, this, [this, backend]() {
+        const QVariantMap tab = m_workspaceSession->tab(backend->activeBufferId());
+        if (tab.value(QStringLiteral("externalChanged")).toBool())
+            backend->reportExternalChange(!QFileInfo::exists(tab.value(QStringLiteral("fileUrl"))
+                                                             .toUrl().toLocalFile()));
+    });
     connect(backend, &Backend::windowEmptied, this, [this, windowId]() {
         QTimer::singleShot(0, this, [this, windowId]() { closeWindow(windowId); });
     });
     m_windows.append({windowId, backend, context, window});
+    connect(backend, &Backend::buffersChanged, this, &WindowManager::syncFileWatcher);
+    syncFileWatcher();
     return backend;
 }
 
@@ -115,9 +128,61 @@ void WindowManager::closeWindow(const QString &windowId) {
         m_windows.removeAt(index);
         m_workspaceSession->removeWindow(window.id);
         m_workspaceSession->saveNow();
+        syncFileWatcher();
         window.root->deleteLater();
         window.context->deleteLater();
         window.backend->deleteLater();
         return;
     }
+}
+
+void WindowManager::syncFileWatcher() {
+    const QStringList watched = m_fileWatcher.files();
+    if (!watched.isEmpty())
+        m_fileWatcher.removePaths(watched);
+
+    QStringList paths;
+    for (const QVariant &window : m_workspaceSession->windows()) {
+        for (const QVariant &tab : window.toMap().value(QStringLiteral("tabs")).toList()) {
+            const QUrl fileUrl(tab.toMap().value(QStringLiteral("fileUrl")).toString());
+            if (fileUrl.isLocalFile() && QFileInfo::exists(fileUrl.toLocalFile()))
+                paths.append(fileUrl.toLocalFile());
+        }
+    }
+    if (!paths.isEmpty())
+        m_fileWatcher.addPaths(paths);
+}
+
+void WindowManager::handleFileChange(const QString &path) {
+    const QUrl fileUrl = QUrl::fromLocalFile(path);
+    const QString tabId = m_workspaceSession->findOpenLocalFile(fileUrl);
+    if (tabId.isEmpty())
+        return;
+
+    const bool deleted = !QFileInfo::exists(path);
+    bool changed = deleted;
+    if (!changed) {
+        QFile file(path);
+        changed = !file.open(QIODevice::ReadOnly)
+            || QString::fromUtf8(file.readAll())
+                != m_workspaceSession->tab(tabId).value(QStringLiteral("text")).toString();
+    }
+    if (!changed) {
+        syncFileWatcher();
+        return;
+    }
+
+    m_workspaceSession->setExternalChange(tabId, true);
+    m_workspaceSession->saveNow();
+    const QString windowId = m_workspaceSession->windowIdForTab(tabId);
+    for (const WritingWindow &window : m_windows) {
+        if (window.id != windowId)
+            continue;
+        if (window.backend->activeBufferId() == tabId)
+            window.backend->reportExternalChange(deleted);
+        else
+            window.backend->refreshBuffers();
+        break;
+    }
+    syncFileWatcher();
 }

--- a/src/windowmanager.h
+++ b/src/windowmanager.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <QObject>
+#include <QList>
+#include <QUrl>
+
+class Backend;
+class QQmlContext;
+class QQmlEngine;
+class WorkspaceSession;
+
+class WindowManager : public QObject {
+    Q_OBJECT
+
+public:
+    WindowManager(WorkspaceSession *workspaceSession, QQmlEngine *engine, const QUrl &qmlUrl,
+                  QObject *parent = nullptr);
+    ~WindowManager() override;
+
+    Backend *createWindow();
+    int windowCount() const;
+
+private:
+    struct WritingWindow {
+        Backend *backend;
+        QQmlContext *context;
+        QObject *root;
+    };
+
+    WorkspaceSession *m_workspaceSession;
+    QQmlEngine *m_engine;
+    QUrl m_qmlUrl;
+    QList<WritingWindow> m_windows;
+};

--- a/src/windowmanager.h
+++ b/src/windowmanager.h
@@ -18,6 +18,7 @@ public:
     ~WindowManager() override;
 
     Backend *createWindow();
+    int restoreWindows();
     int windowCount() const;
 
 private:
@@ -26,6 +27,8 @@ private:
         QQmlContext *context;
         QObject *root;
     };
+
+    Backend *createWindow(const QString &windowId);
 
     WorkspaceSession *m_workspaceSession;
     QQmlEngine *m_engine;

--- a/src/windowmanager.h
+++ b/src/windowmanager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QFileSystemWatcher>
 #include <QList>
 #include <QUrl>
 
@@ -35,6 +36,8 @@ private:
     Backend *createWindow(const QString &windowId);
     void activateTab(const QString &tabId);
     void closeWindow(const QString &windowId);
+    void syncFileWatcher();
+    void handleFileChange(const QString &path);
 
     WorkspaceSession *m_workspaceSession;
     QQmlEngine *m_engine;
@@ -42,4 +45,5 @@ private:
     QList<WritingWindow> m_windows;
     bool m_darkMode = true;
     qreal m_textScale = 1.0;
+    QFileSystemWatcher m_fileWatcher;
 };

--- a/src/windowmanager.h
+++ b/src/windowmanager.h
@@ -20,18 +20,26 @@ public:
     Backend *createWindow();
     int restoreWindows();
     int windowCount() const;
+    Backend *primaryBackend() const;
+    void setDarkMode(bool darkMode);
+    void setTextScale(qreal textScale);
 
 private:
     struct WritingWindow {
+        QString id;
         Backend *backend;
         QQmlContext *context;
         QObject *root;
     };
 
     Backend *createWindow(const QString &windowId);
+    void activateTab(const QString &tabId);
+    void closeWindow(const QString &windowId);
 
     WorkspaceSession *m_workspaceSession;
     QQmlEngine *m_engine;
     QUrl m_qmlUrl;
     QList<WritingWindow> m_windows;
+    bool m_darkMode = true;
+    qreal m_textScale = 1.0;
 };

--- a/src/windowmanager.h
+++ b/src/windowmanager.h
@@ -20,6 +20,7 @@ public:
 
     Backend *createWindow();
     int restoreWindows();
+    int recoverLegacySnapshots();
     int windowCount() const;
     Backend *primaryBackend() const;
     void setDarkMode(bool darkMode);

--- a/src/workspacesession.cpp
+++ b/src/workspacesession.cpp
@@ -214,6 +214,33 @@ bool WorkspaceSession::moveActiveTab(const QString &windowId, int direction) {
     return false;
 }
 
+bool WorkspaceSession::removeTab(const QString &windowId, const QString &tabId) {
+    for (QVariant &value : m_windows) {
+        QVariantMap window = value.toMap();
+        if (window.value(QStringLiteral("id")).toString() != windowId)
+            continue;
+
+        QVariantList tabs = window.value(QStringLiteral("tabs")).toList();
+        for (int index = 0; index < tabs.size(); ++index) {
+            if (tabs.at(index).toMap().value(QStringLiteral("id")).toString() != tabId)
+                continue;
+
+            tabs.removeAt(index);
+            window.insert(QStringLiteral("tabs"), tabs);
+            if (window.value(QStringLiteral("activeTabId")).toString() == tabId) {
+                window.insert(QStringLiteral("activeTabId"), tabs.isEmpty()
+                              ? QString()
+                              : tabs.at(qMin(index, tabs.size() - 1)).toMap()
+                                    .value(QStringLiteral("id")).toString());
+            }
+            value = window;
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
 bool WorkspaceSession::restore() {
     QFile file(sessionPath());
     if (!file.open(QIODevice::ReadOnly))

--- a/src/workspacesession.cpp
+++ b/src/workspacesession.cpp
@@ -110,6 +110,10 @@ bool windowFromJson(const QJsonValue &value, QVariantMap *window) {
 
 WorkspaceSession::WorkspaceSession(const QString &stateDirectory) : m_stateDirectory(stateDirectory) {}
 
+QString WorkspaceSession::stateDirectory() const {
+    return m_stateDirectory;
+}
+
 QVariantList WorkspaceSession::windows() const {
     return m_windows;
 }

--- a/src/workspacesession.cpp
+++ b/src/workspacesession.cpp
@@ -312,6 +312,16 @@ bool WorkspaceSession::removeTab(const QString &windowId, const QString &tabId) 
     return false;
 }
 
+bool WorkspaceSession::removeWindow(const QString &windowId) {
+    for (int index = 0; index < m_windows.size(); ++index) {
+        if (m_windows.at(index).toMap().value(QStringLiteral("id")).toString() != windowId)
+            continue;
+        m_windows.removeAt(index);
+        return true;
+    }
+    return false;
+}
+
 bool WorkspaceSession::updateWindowGeometry(const QString &windowId, int x, int y, int width,
                                             int height, bool maximized) {
     for (QVariant &value : m_windows) {
@@ -371,9 +381,6 @@ bool WorkspaceSession::restore() {
 }
 
 bool WorkspaceSession::saveNow() const {
-    if (m_windows.isEmpty())
-        return false;
-
     QDir().mkpath(m_stateDirectory);
     QSaveFile file(sessionPath());
     if (!file.open(QIODevice::WriteOnly))

--- a/src/workspacesession.cpp
+++ b/src/workspacesession.cpp
@@ -111,6 +111,24 @@ QVariantList WorkspaceSession::windows() const {
     return m_windows;
 }
 
+QVariantList WorkspaceSession::tabs(const QString &windowId) const {
+    for (const QVariant &value : m_windows) {
+        const QVariantMap window = value.toMap();
+        if (window.value(QStringLiteral("id")).toString() == windowId)
+            return window.value(QStringLiteral("tabs")).toList();
+    }
+    return {};
+}
+
+QString WorkspaceSession::activeTabId(const QString &windowId) const {
+    for (const QVariant &value : m_windows) {
+        const QVariantMap window = value.toMap();
+        if (window.value(QStringLiteral("id")).toString() == windowId)
+            return window.value(QStringLiteral("activeTabId")).toString();
+    }
+    return {};
+}
+
 QString WorkspaceSession::createWindow(int x, int y, int width, int height, bool maximized) {
     const QString id = QUuid::createUuid().toString(QUuid::WithoutBraces);
     m_windows.append(QVariantMap{{QStringLiteral("id"), id},
@@ -150,6 +168,35 @@ QString WorkspaceSession::createTab(const QString &windowId, const QUrl &fileUrl
         return id;
     }
     return {};
+}
+
+bool WorkspaceSession::updateTab(const QString &windowId, const QString &tabId,
+                                 const QUrl &fileUrl, const QString &text,
+                                 int cursorPosition, int selectionStart,
+                                 int selectionEnd, bool modified) {
+    for (QVariant &windowValue : m_windows) {
+        QVariantMap window = windowValue.toMap();
+        if (window.value(QStringLiteral("id")).toString() != windowId)
+            continue;
+        QVariantList tabs = window.value(QStringLiteral("tabs")).toList();
+        for (QVariant &tabValue : tabs) {
+            QVariantMap tab = tabValue.toMap();
+            if (tab.value(QStringLiteral("id")).toString() != tabId)
+                continue;
+            tab.insert(QStringLiteral("fileUrl"), fileUrl.toString());
+            tab.insert(QStringLiteral("text"), text);
+            tab.insert(QStringLiteral("cursorPosition"), qBound(0, cursorPosition, text.size()));
+            tab.insert(QStringLiteral("selectionStart"), qBound(0, selectionStart, text.size()));
+            tab.insert(QStringLiteral("selectionEnd"), qBound(0, selectionEnd, text.size()));
+            tab.insert(QStringLiteral("modified"), modified);
+            tabValue = tab;
+            window.insert(QStringLiteral("tabs"), tabs);
+            windowValue = window;
+            return true;
+        }
+        return false;
+    }
+    return false;
 }
 
 QString WorkspaceSession::findOpenLocalFile(const QUrl &fileUrl) const {

--- a/src/workspacesession.cpp
+++ b/src/workspacesession.cpp
@@ -1,0 +1,278 @@
+#include "workspacesession.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSaveFile>
+#include <QSet>
+#include <QUuid>
+
+namespace {
+constexpr int sessionVersion = 1;
+
+QJsonObject jsonTab(const QVariantMap &tab) {
+    return {{QStringLiteral("id"), tab.value(QStringLiteral("id")).toString()},
+            {QStringLiteral("fileUrl"), tab.value(QStringLiteral("fileUrl")).toString()},
+            {QStringLiteral("text"), tab.value(QStringLiteral("text")).toString()},
+            {QStringLiteral("cursorPosition"), tab.value(QStringLiteral("cursorPosition")).toInt()},
+            {QStringLiteral("selectionStart"), tab.value(QStringLiteral("selectionStart")).toInt()},
+            {QStringLiteral("selectionEnd"), tab.value(QStringLiteral("selectionEnd")).toInt()},
+            {QStringLiteral("modified"), tab.value(QStringLiteral("modified")).toBool()}};
+}
+
+bool tabFromJson(const QJsonValue &value, QVariantMap *tab) {
+    if (!value.isObject())
+        return false;
+
+    const QJsonObject object = value.toObject();
+    const QJsonValue id = object.value(QStringLiteral("id"));
+    const QJsonValue fileUrl = object.value(QStringLiteral("fileUrl"));
+    const QJsonValue text = object.value(QStringLiteral("text"));
+    const QJsonValue cursorPosition = object.value(QStringLiteral("cursorPosition"));
+    const QJsonValue selectionStart = object.value(QStringLiteral("selectionStart"));
+    const QJsonValue selectionEnd = object.value(QStringLiteral("selectionEnd"));
+    const QJsonValue modified = object.value(QStringLiteral("modified"));
+    if (!id.isString() || id.toString().isEmpty() || !fileUrl.isString() || !text.isString()
+            || !cursorPosition.isDouble() || !selectionStart.isDouble() || !selectionEnd.isDouble()
+            || !modified.isBool())
+        return false;
+
+    const int textLength = text.toString().size();
+    *tab = {{QStringLiteral("id"), id.toString()},
+            {QStringLiteral("fileUrl"), fileUrl.toString()},
+            {QStringLiteral("text"), text.toString()},
+            {QStringLiteral("cursorPosition"), qBound(0, cursorPosition.toInt(), textLength)},
+            {QStringLiteral("selectionStart"), qBound(0, selectionStart.toInt(), textLength)},
+            {QStringLiteral("selectionEnd"), qBound(0, selectionEnd.toInt(), textLength)},
+            {QStringLiteral("modified"), modified.toBool()}};
+    return true;
+}
+
+QJsonObject jsonWindow(const QVariantMap &window) {
+    QJsonArray tabs;
+    for (const QVariant &value : window.value(QStringLiteral("tabs")).toList())
+        tabs.append(jsonTab(value.toMap()));
+    return {{QStringLiteral("id"), window.value(QStringLiteral("id")).toString()},
+            {QStringLiteral("x"), window.value(QStringLiteral("x")).toInt()},
+            {QStringLiteral("y"), window.value(QStringLiteral("y")).toInt()},
+            {QStringLiteral("width"), window.value(QStringLiteral("width")).toInt()},
+            {QStringLiteral("height"), window.value(QStringLiteral("height")).toInt()},
+            {QStringLiteral("maximized"), window.value(QStringLiteral("maximized")).toBool()},
+            {QStringLiteral("activeTabId"), window.value(QStringLiteral("activeTabId")).toString()},
+            {QStringLiteral("tabs"), tabs}};
+}
+
+bool windowFromJson(const QJsonValue &value, QVariantMap *window) {
+    if (!value.isObject())
+        return false;
+
+    const QJsonObject object = value.toObject();
+    const QJsonValue id = object.value(QStringLiteral("id"));
+    const QJsonValue activeTabId = object.value(QStringLiteral("activeTabId"));
+    const QJsonValue tabs = object.value(QStringLiteral("tabs"));
+    if (!id.isString() || id.toString().isEmpty() || !object.value(QStringLiteral("x")).isDouble()
+            || !object.value(QStringLiteral("y")).isDouble()
+            || !object.value(QStringLiteral("width")).isDouble()
+            || !object.value(QStringLiteral("height")).isDouble()
+            || !object.value(QStringLiteral("maximized")).isBool() || !activeTabId.isString()
+            || !tabs.isArray())
+        return false;
+
+    QVariantList restoredTabs;
+    QSet<QString> tabIds;
+    for (const QJsonValue &tabValue : tabs.toArray()) {
+        QVariantMap tab;
+        if (!tabFromJson(tabValue, &tab) || tabIds.contains(tab.value(QStringLiteral("id")).toString()))
+            return false;
+        tabIds.insert(tab.value(QStringLiteral("id")).toString());
+        restoredTabs.append(tab);
+    }
+    if (restoredTabs.isEmpty() || !tabIds.contains(activeTabId.toString()))
+        return false;
+
+    *window = {{QStringLiteral("id"), id.toString()},
+               {QStringLiteral("x"), object.value(QStringLiteral("x")).toInt()},
+               {QStringLiteral("y"), object.value(QStringLiteral("y")).toInt()},
+               {QStringLiteral("width"), object.value(QStringLiteral("width")).toInt()},
+               {QStringLiteral("height"), object.value(QStringLiteral("height")).toInt()},
+               {QStringLiteral("maximized"), object.value(QStringLiteral("maximized")).toBool()},
+               {QStringLiteral("activeTabId"), activeTabId.toString()},
+               {QStringLiteral("tabs"), restoredTabs}};
+    return true;
+}
+}
+
+WorkspaceSession::WorkspaceSession(const QString &stateDirectory) : m_stateDirectory(stateDirectory) {}
+
+QVariantList WorkspaceSession::windows() const {
+    return m_windows;
+}
+
+QString WorkspaceSession::createWindow(int x, int y, int width, int height, bool maximized) {
+    const QString id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    m_windows.append(QVariantMap{{QStringLiteral("id"), id},
+                                 {QStringLiteral("x"), x},
+                                 {QStringLiteral("y"), y},
+                                 {QStringLiteral("width"), width},
+                                 {QStringLiteral("height"), height},
+                                 {QStringLiteral("maximized"), maximized},
+                                 {QStringLiteral("activeTabId"), QString()},
+                                 {QStringLiteral("tabs"), QVariantList()}});
+    return id;
+}
+
+QString WorkspaceSession::createTab(const QString &windowId, const QUrl &fileUrl,
+                                    const QString &text, int cursorPosition,
+                                    int selectionStart, int selectionEnd, bool modified) {
+    if (!findOpenLocalFile(fileUrl).isEmpty())
+        return {};
+
+    for (QVariant &value : m_windows) {
+        QVariantMap window = value.toMap();
+        if (window.value(QStringLiteral("id")).toString() != windowId)
+            continue;
+
+        const QString id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+        QVariantList tabs = window.value(QStringLiteral("tabs")).toList();
+        tabs.append(QVariantMap{{QStringLiteral("id"), id},
+                                {QStringLiteral("fileUrl"), fileUrl.toString()},
+                                {QStringLiteral("text"), text},
+                                {QStringLiteral("cursorPosition"), qBound(0, cursorPosition, text.size())},
+                                {QStringLiteral("selectionStart"), qBound(0, selectionStart, text.size())},
+                                {QStringLiteral("selectionEnd"), qBound(0, selectionEnd, text.size())},
+                                {QStringLiteral("modified"), modified}});
+        window.insert(QStringLiteral("tabs"), tabs);
+        window.insert(QStringLiteral("activeTabId"), id);
+        value = window;
+        return id;
+    }
+    return {};
+}
+
+QString WorkspaceSession::findOpenLocalFile(const QUrl &fileUrl) const {
+    if (!fileUrl.isLocalFile())
+        return {};
+
+    const QString targetPath = QFileInfo(fileUrl.toLocalFile()).absoluteFilePath();
+    for (const QVariant &windowValue : m_windows) {
+        for (const QVariant &tabValue : windowValue.toMap().value(QStringLiteral("tabs")).toList()) {
+            const QUrl openUrl(tabValue.toMap().value(QStringLiteral("fileUrl")).toString());
+            if (openUrl.isLocalFile()
+                    && QFileInfo(openUrl.toLocalFile()).absoluteFilePath() == targetPath)
+                return tabValue.toMap().value(QStringLiteral("id")).toString();
+        }
+    }
+    return {};
+}
+
+bool WorkspaceSession::setActiveTab(const QString &windowId, const QString &tabId) {
+    for (QVariant &value : m_windows) {
+        QVariantMap window = value.toMap();
+        if (window.value(QStringLiteral("id")).toString() != windowId)
+            continue;
+
+        for (const QVariant &tabValue : window.value(QStringLiteral("tabs")).toList()) {
+            if (tabValue.toMap().value(QStringLiteral("id")).toString() != tabId)
+                continue;
+            window.insert(QStringLiteral("activeTabId"), tabId);
+            value = window;
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
+bool WorkspaceSession::moveActiveTab(const QString &windowId, int direction) {
+    if (direction != -1 && direction != 1)
+        return false;
+
+    for (QVariant &value : m_windows) {
+        QVariantMap window = value.toMap();
+        if (window.value(QStringLiteral("id")).toString() != windowId)
+            continue;
+
+        QVariantList tabs = window.value(QStringLiteral("tabs")).toList();
+        const QString activeTabId = window.value(QStringLiteral("activeTabId")).toString();
+        for (int index = 0; index < tabs.size(); ++index) {
+            if (tabs.at(index).toMap().value(QStringLiteral("id")).toString() != activeTabId)
+                continue;
+
+            const int destination = index + direction;
+            if (destination < 0 || destination >= tabs.size())
+                return false;
+            tabs.swapItemsAt(index, destination);
+            window.insert(QStringLiteral("tabs"), tabs);
+            value = window;
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
+bool WorkspaceSession::restore() {
+    QFile file(sessionPath());
+    if (!file.open(QIODevice::ReadOnly))
+        return false;
+
+    const QJsonDocument document = QJsonDocument::fromJson(file.readAll());
+    if (!document.isObject())
+        return false;
+
+    const QJsonObject root = document.object();
+    if (root.value(QStringLiteral("version")).toInt() != sessionVersion
+            || !root.value(QStringLiteral("windows")).isArray())
+        return false;
+
+    QVariantList restoredWindows;
+    QSet<QString> windowIds;
+    QSet<QString> openLocalPaths;
+    for (const QJsonValue &value : root.value(QStringLiteral("windows")).toArray()) {
+        QVariantMap window;
+        if (!windowFromJson(value, &window)
+                || windowIds.contains(window.value(QStringLiteral("id")).toString()))
+            return false;
+        for (const QVariant &tabValue : window.value(QStringLiteral("tabs")).toList()) {
+            const QUrl fileUrl(tabValue.toMap().value(QStringLiteral("fileUrl")).toString());
+            if (!fileUrl.isLocalFile())
+                continue;
+            const QString path = QFileInfo(fileUrl.toLocalFile()).absoluteFilePath();
+            if (openLocalPaths.contains(path))
+                return false;
+            openLocalPaths.insert(path);
+        }
+        windowIds.insert(window.value(QStringLiteral("id")).toString());
+        restoredWindows.append(window);
+    }
+    if (restoredWindows.isEmpty())
+        return false;
+
+    m_windows = restoredWindows;
+    return true;
+}
+
+bool WorkspaceSession::saveNow() const {
+    if (m_windows.isEmpty())
+        return false;
+
+    QDir().mkpath(m_stateDirectory);
+    QSaveFile file(sessionPath());
+    if (!file.open(QIODevice::WriteOnly))
+        return false;
+
+    QJsonArray windows;
+    for (const QVariant &value : m_windows)
+        windows.append(jsonWindow(value.toMap()));
+    file.write(QJsonDocument(QJsonObject{{QStringLiteral("version"), sessionVersion},
+                                         {QStringLiteral("windows"), windows}})
+                   .toJson(QJsonDocument::Compact));
+    return file.commit();
+}
+
+QString WorkspaceSession::sessionPath() const {
+    return QDir(m_stateDirectory).filePath(QStringLiteral("session.json"));
+}

--- a/src/workspacesession.cpp
+++ b/src/workspacesession.cpp
@@ -111,6 +111,15 @@ QVariantList WorkspaceSession::windows() const {
     return m_windows;
 }
 
+QVariantMap WorkspaceSession::window(const QString &windowId) const {
+    for (const QVariant &value : m_windows) {
+        const QVariantMap window = value.toMap();
+        if (window.value(QStringLiteral("id")).toString() == windowId)
+            return window;
+    }
+    return {};
+}
+
 QVariantList WorkspaceSession::tabs(const QString &windowId) const {
     for (const QVariant &value : m_windows) {
         const QVariantMap window = value.toMap();
@@ -174,6 +183,10 @@ bool WorkspaceSession::updateTab(const QString &windowId, const QString &tabId,
                                  const QUrl &fileUrl, const QString &text,
                                  int cursorPosition, int selectionStart,
                                  int selectionEnd, bool modified) {
+    const QString openTabId = findOpenLocalFile(fileUrl);
+    if (!openTabId.isEmpty() && openTabId != tabId)
+        return false;
+
     for (QVariant &windowValue : m_windows) {
         QVariantMap window = windowValue.toMap();
         if (window.value(QStringLiteral("id")).toString() != windowId)
@@ -210,6 +223,17 @@ QString WorkspaceSession::findOpenLocalFile(const QUrl &fileUrl) const {
             if (openUrl.isLocalFile()
                     && QFileInfo(openUrl.toLocalFile()).absoluteFilePath() == targetPath)
                 return tabValue.toMap().value(QStringLiteral("id")).toString();
+        }
+    }
+    return {};
+}
+
+QString WorkspaceSession::windowIdForTab(const QString &tabId) const {
+    for (const QVariant &windowValue : m_windows) {
+        const QVariantMap window = windowValue.toMap();
+        for (const QVariant &tabValue : window.value(QStringLiteral("tabs")).toList()) {
+            if (tabValue.toMap().value(QStringLiteral("id")).toString() == tabId)
+                return window.value(QStringLiteral("id")).toString();
         }
     }
     return {};
@@ -284,6 +308,23 @@ bool WorkspaceSession::removeTab(const QString &windowId, const QString &tabId) 
             return true;
         }
         return false;
+    }
+    return false;
+}
+
+bool WorkspaceSession::updateWindowGeometry(const QString &windowId, int x, int y, int width,
+                                            int height, bool maximized) {
+    for (QVariant &value : m_windows) {
+        QVariantMap window = value.toMap();
+        if (window.value(QStringLiteral("id")).toString() != windowId)
+            continue;
+        window.insert(QStringLiteral("x"), x);
+        window.insert(QStringLiteral("y"), y);
+        window.insert(QStringLiteral("width"), width);
+        window.insert(QStringLiteral("height"), height);
+        window.insert(QStringLiteral("maximized"), maximized);
+        value = window;
+        return true;
     }
     return false;
 }

--- a/src/workspacesession.cpp
+++ b/src/workspacesession.cpp
@@ -11,7 +11,7 @@
 #include <QUuid>
 
 namespace {
-constexpr int sessionVersion = 1;
+constexpr int sessionVersion = 2;
 
 QJsonObject jsonTab(const QVariantMap &tab) {
     return {{QStringLiteral("id"), tab.value(QStringLiteral("id")).toString()},
@@ -20,7 +20,8 @@ QJsonObject jsonTab(const QVariantMap &tab) {
             {QStringLiteral("cursorPosition"), tab.value(QStringLiteral("cursorPosition")).toInt()},
             {QStringLiteral("selectionStart"), tab.value(QStringLiteral("selectionStart")).toInt()},
             {QStringLiteral("selectionEnd"), tab.value(QStringLiteral("selectionEnd")).toInt()},
-            {QStringLiteral("modified"), tab.value(QStringLiteral("modified")).toBool()}};
+            {QStringLiteral("modified"), tab.value(QStringLiteral("modified")).toBool()},
+            {QStringLiteral("externalChanged"), tab.value(QStringLiteral("externalChanged")).toBool()}};
 }
 
 bool tabFromJson(const QJsonValue &value, QVariantMap *tab) {
@@ -35,9 +36,10 @@ bool tabFromJson(const QJsonValue &value, QVariantMap *tab) {
     const QJsonValue selectionStart = object.value(QStringLiteral("selectionStart"));
     const QJsonValue selectionEnd = object.value(QStringLiteral("selectionEnd"));
     const QJsonValue modified = object.value(QStringLiteral("modified"));
+    const QJsonValue externalChanged = object.value(QStringLiteral("externalChanged"));
     if (!id.isString() || id.toString().isEmpty() || !fileUrl.isString() || !text.isString()
             || !cursorPosition.isDouble() || !selectionStart.isDouble() || !selectionEnd.isDouble()
-            || !modified.isBool())
+            || !modified.isBool() || !externalChanged.isBool())
         return false;
 
     const int textLength = text.toString().size();
@@ -47,7 +49,8 @@ bool tabFromJson(const QJsonValue &value, QVariantMap *tab) {
             {QStringLiteral("cursorPosition"), qBound(0, cursorPosition.toInt(), textLength)},
             {QStringLiteral("selectionStart"), qBound(0, selectionStart.toInt(), textLength)},
             {QStringLiteral("selectionEnd"), qBound(0, selectionEnd.toInt(), textLength)},
-            {QStringLiteral("modified"), modified.toBool()}};
+            {QStringLiteral("modified"), modified.toBool()},
+            {QStringLiteral("externalChanged"), externalChanged.toBool()}};
     return true;
 }
 
@@ -120,6 +123,17 @@ QVariantMap WorkspaceSession::window(const QString &windowId) const {
     return {};
 }
 
+QVariantMap WorkspaceSession::tab(const QString &tabId) const {
+    for (const QVariant &windowValue : m_windows) {
+        for (const QVariant &tabValue : windowValue.toMap().value(QStringLiteral("tabs")).toList()) {
+            const QVariantMap tab = tabValue.toMap();
+            if (tab.value(QStringLiteral("id")).toString() == tabId)
+                return tab;
+        }
+    }
+    return {};
+}
+
 QVariantList WorkspaceSession::tabs(const QString &windowId) const {
     for (const QVariant &value : m_windows) {
         const QVariantMap window = value.toMap();
@@ -170,7 +184,8 @@ QString WorkspaceSession::createTab(const QString &windowId, const QUrl &fileUrl
                                 {QStringLiteral("cursorPosition"), qBound(0, cursorPosition, text.size())},
                                 {QStringLiteral("selectionStart"), qBound(0, selectionStart, text.size())},
                                 {QStringLiteral("selectionEnd"), qBound(0, selectionEnd, text.size())},
-                                {QStringLiteral("modified"), modified}});
+                                {QStringLiteral("modified"), modified},
+                                {QStringLiteral("externalChanged"), false}});
         window.insert(QStringLiteral("tabs"), tabs);
         window.insert(QStringLiteral("activeTabId"), id);
         value = window;
@@ -318,6 +333,24 @@ bool WorkspaceSession::removeWindow(const QString &windowId) {
             continue;
         m_windows.removeAt(index);
         return true;
+    }
+    return false;
+}
+
+bool WorkspaceSession::setExternalChange(const QString &tabId, bool changed) {
+    for (QVariant &windowValue : m_windows) {
+        QVariantMap window = windowValue.toMap();
+        QVariantList tabs = window.value(QStringLiteral("tabs")).toList();
+        for (QVariant &tabValue : tabs) {
+            QVariantMap tab = tabValue.toMap();
+            if (tab.value(QStringLiteral("id")).toString() != tabId)
+                continue;
+            tab.insert(QStringLiteral("externalChanged"), changed);
+            tabValue = tab;
+            window.insert(QStringLiteral("tabs"), tabs);
+            windowValue = window;
+            return true;
+        }
     }
     return false;
 }

--- a/src/workspacesession.h
+++ b/src/workspacesession.h
@@ -9,6 +9,7 @@ public:
     explicit WorkspaceSession(const QString &stateDirectory);
 
     QVariantList windows() const;
+    QVariantMap window(const QString &windowId) const;
     QVariantList tabs(const QString &windowId) const;
     QString activeTabId(const QString &windowId) const;
     QString createWindow(int x, int y, int width, int height, bool maximized);
@@ -18,9 +19,12 @@ public:
                    const QString &text, int cursorPosition, int selectionStart,
                    int selectionEnd, bool modified);
     QString findOpenLocalFile(const QUrl &fileUrl) const;
+    QString windowIdForTab(const QString &tabId) const;
     bool setActiveTab(const QString &windowId, const QString &tabId);
     bool moveActiveTab(const QString &windowId, int direction);
     bool removeTab(const QString &windowId, const QString &tabId);
+    bool updateWindowGeometry(const QString &windowId, int x, int y, int width, int height,
+                              bool maximized);
     bool restore();
     bool saveNow() const;
 

--- a/src/workspacesession.h
+++ b/src/workspacesession.h
@@ -9,9 +9,14 @@ public:
     explicit WorkspaceSession(const QString &stateDirectory);
 
     QVariantList windows() const;
+    QVariantList tabs(const QString &windowId) const;
+    QString activeTabId(const QString &windowId) const;
     QString createWindow(int x, int y, int width, int height, bool maximized);
     QString createTab(const QString &windowId, const QUrl &fileUrl, const QString &text,
                       int cursorPosition, int selectionStart, int selectionEnd, bool modified);
+    bool updateTab(const QString &windowId, const QString &tabId, const QUrl &fileUrl,
+                   const QString &text, int cursorPosition, int selectionStart,
+                   int selectionEnd, bool modified);
     QString findOpenLocalFile(const QUrl &fileUrl) const;
     bool setActiveTab(const QString &windowId, const QString &tabId);
     bool moveActiveTab(const QString &windowId, int direction);

--- a/src/workspacesession.h
+++ b/src/workspacesession.h
@@ -15,6 +15,7 @@ public:
     QString findOpenLocalFile(const QUrl &fileUrl) const;
     bool setActiveTab(const QString &windowId, const QString &tabId);
     bool moveActiveTab(const QString &windowId, int direction);
+    bool removeTab(const QString &windowId, const QString &tabId);
     bool restore();
     bool saveNow() const;
 

--- a/src/workspacesession.h
+++ b/src/workspacesession.h
@@ -10,6 +10,7 @@ public:
 
     QVariantList windows() const;
     QVariantMap window(const QString &windowId) const;
+    QVariantMap tab(const QString &tabId) const;
     QVariantList tabs(const QString &windowId) const;
     QString activeTabId(const QString &windowId) const;
     QString createWindow(int x, int y, int width, int height, bool maximized);
@@ -24,6 +25,7 @@ public:
     bool moveActiveTab(const QString &windowId, int direction);
     bool removeTab(const QString &windowId, const QString &tabId);
     bool removeWindow(const QString &windowId);
+    bool setExternalChange(const QString &tabId, bool changed);
     bool updateWindowGeometry(const QString &windowId, int x, int y, int width, int height,
                               bool maximized);
     bool restore();

--- a/src/workspacesession.h
+++ b/src/workspacesession.h
@@ -23,6 +23,7 @@ public:
     bool setActiveTab(const QString &windowId, const QString &tabId);
     bool moveActiveTab(const QString &windowId, int direction);
     bool removeTab(const QString &windowId, const QString &tabId);
+    bool removeWindow(const QString &windowId);
     bool updateWindowGeometry(const QString &windowId, int x, int y, int width, int height,
                               bool maximized);
     bool restore();

--- a/src/workspacesession.h
+++ b/src/workspacesession.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QString>
+#include <QUrl>
+#include <QVariantList>
+
+class WorkspaceSession {
+public:
+    explicit WorkspaceSession(const QString &stateDirectory);
+
+    QVariantList windows() const;
+    QString createWindow(int x, int y, int width, int height, bool maximized);
+    QString createTab(const QString &windowId, const QUrl &fileUrl, const QString &text,
+                      int cursorPosition, int selectionStart, int selectionEnd, bool modified);
+    QString findOpenLocalFile(const QUrl &fileUrl) const;
+    bool setActiveTab(const QString &windowId, const QString &tabId);
+    bool moveActiveTab(const QString &windowId, int direction);
+    bool restore();
+    bool saveNow() const;
+
+private:
+    QString sessionPath() const;
+
+    QString m_stateDirectory;
+    QVariantList m_windows;
+};

--- a/src/workspacesession.h
+++ b/src/workspacesession.h
@@ -8,6 +8,7 @@ class WorkspaceSession {
 public:
     explicit WorkspaceSession(const QString &stateDirectory);
 
+    QString stateDirectory() const;
     QVariantList windows() const;
     QVariantMap window(const QString &windowId) const;
     QVariantMap tab(const QString &tabId) const;

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -6,9 +6,11 @@ TARGET = tst_omawrite
 INCLUDEPATH += ../src
 SOURCES += \
     tst_omawrite.cpp \
+    ../src/buffersession.cpp \
     ../src/backend.cpp \
     ../src/markdownhighlighter.cpp
 HEADERS += \
+    ../src/buffersession.h \
     ../src/backend.h \
     ../src/markdownhighlighter.h
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -8,11 +8,13 @@ SOURCES += \
     tst_omawrite.cpp \
     ../src/buffersession.cpp \
     ../src/workspacesession.cpp \
+    ../src/windowmanager.cpp \
     ../src/backend.cpp \
     ../src/markdownhighlighter.cpp
 HEADERS += \
     ../src/buffersession.h \
     ../src/workspacesession.h \
+    ../src/windowmanager.h \
     ../src/backend.h \
     ../src/markdownhighlighter.h
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -7,10 +7,12 @@ INCLUDEPATH += ../src
 SOURCES += \
     tst_omawrite.cpp \
     ../src/buffersession.cpp \
+    ../src/workspacesession.cpp \
     ../src/backend.cpp \
     ../src/markdownhighlighter.cpp
 HEADERS += \
     ../src/buffersession.h \
+    ../src/workspacesession.h \
     ../src/backend.h \
     ../src/markdownhighlighter.h
 

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -190,6 +190,23 @@ private slots:
         QVERIFY(restoredWindow.value(QStringLiteral("activeTabId")).toString().isEmpty());
     }
 
+    void backendReadsTabsFromItsWorkspaceWindow() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+
+        WorkspaceSession session(stateDirectory.path());
+        const QString firstWindow = session.createWindow(0, 0, 900, 700, false);
+        const QString firstTab = session.createTab(firstWindow, QUrl(), QStringLiteral("first"),
+                                                   2, 1, 2, true);
+        const QString secondWindow = session.createWindow(0, 0, 800, 600, false);
+        session.createTab(secondWindow, QUrl(), QStringLiteral("second"), 0, 0, 0, false);
+
+        Backend backend(&session, firstWindow);
+        QCOMPARE(backend.buffers().size(), 1);
+        QCOMPARE(backend.activeBufferId(), firstTab);
+        QCOMPARE(backend.activeBufferText(), QStringLiteral("first"));
+    }
+
     void preservesBufferTextWhenUpdatingCaret() {
         QTemporaryDir stateDirectory;
         QVERIFY(stateDirectory.isValid());

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -105,6 +105,18 @@ private slots:
         QCOMPARE(file.readAll(), QByteArray("original"));
     }
 
+    void backendCreatesAndSelectsBuffers() {
+        Backend backend;
+
+        QCOMPARE(backend.buffers().size(), 1);
+        const QString first = backend.activeBufferId();
+        const QString second = backend.newBuffer();
+        QCOMPARE(backend.buffers().size(), 2);
+        QCOMPARE(backend.activeBufferId(), second);
+        QVERIFY(backend.selectBuffer(first));
+        QCOMPARE(backend.activeBufferId(), first);
+    }
+
     void findsInlineMarkdownRanges() {
         const auto markup = MarkdownHighlighter::inlineMarkup(
             QStringLiteral("**bold** and *italic* and [site](https://example.com)"));

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -240,13 +240,56 @@ private slots:
         WindowManager manager(&session, &engine, QUrl::fromLocalFile(mainQmlPath));
 
         Backend *first = manager.createWindow();
-        Backend *second = manager.createWindow();
+        QVERIFY(first);
+        first->newWindow();
 
+        QTRY_COMPARE(manager.windowCount(), 2);
+        QCOMPARE(session.windows().size(), 2);
+    }
+
+    void windowManagerClosesTheLastTabWithItsWindow() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        WorkspaceSession session(stateDirectory.path());
+        QQmlEngine engine;
+        WindowManager manager(&session, &engine, QUrl::fromLocalFile(mainQmlPath));
+        Backend *backend = manager.createWindow();
+        QVERIFY(backend);
+
+        QVERIFY(backend->discardActiveBuffer());
+        QTRY_COMPARE(manager.windowCount(), 0);
+        QVERIFY(session.windows().isEmpty());
+    }
+
+    void windowManagerActivatesAnExistingFileTab() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+        const QString filePath = stateDirectory.filePath(QStringLiteral("note.md"));
+        QFile file(filePath);
+        QVERIFY(file.open(QIODevice::WriteOnly | QIODevice::Text));
+        file.write("note");
+        file.close();
+
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        WorkspaceSession session(stateDirectory.path());
+        QQmlEngine engine;
+        WindowManager manager(&session, &engine, QUrl::fromLocalFile(mainQmlPath));
+        Backend *first = manager.createWindow();
+        Backend *second = manager.createWindow();
         QVERIFY(first);
         QVERIFY(second);
-        QVERIFY(first != second);
-        QCOMPARE(manager.windowCount(), 2);
-        QCOMPARE(session.windows().size(), 2);
+
+        first->open(QUrl::fromLocalFile(filePath));
+        second->open(QUrl::fromLocalFile(filePath));
+
+        QVERIFY(!session.findOpenLocalFile(QUrl::fromLocalFile(filePath)).isEmpty());
+        QCOMPARE(session.windows().at(0).toMap().value(QStringLiteral("tabs")).toList().size(), 2);
+        QCOMPARE(session.windows().at(1).toMap().value(QStringLiteral("tabs")).toList().size(), 1);
     }
 
     void windowManagerRestoresWritingWindows() {
@@ -416,6 +459,31 @@ private slots:
         QVERIFY(backend.selectBuffer(second));
         QVERIFY(QMetaObject::invokeMethod(window.get(), "selectAdjacentTab", Q_ARG(QVariant, 1)));
         QCOMPARE(backend.activeBufferId(), third);
+    }
+
+    void scopesDocumentShortcutsToTheirWindow() {
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        Backend backend;
+        QQmlEngine engine;
+        engine.rootContext()->setContextProperty(QStringLiteral("backend"), &backend);
+        QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> window(component.create());
+        QVERIFY2(window, qPrintable(component.errorString()));
+
+        for (const QString &name : {QStringLiteral("newTabShortcut"),
+                                    QStringLiteral("closeTabShortcut"),
+                                    QStringLiteral("nextTabShortcut"),
+                                    QStringLiteral("previousTabShortcut"),
+                                    QStringLiteral("moveTabLeftShortcut"),
+                                    QStringLiteral("moveTabRightShortcut"),
+                                    QStringLiteral("newWindowShortcut")}) {
+            QObject *shortcut = window->findChild<QObject *>(name);
+            QVERIFY(shortcut);
+            QCOMPARE(shortcut->property("context").toInt(), static_cast<int>(Qt::WindowShortcut));
+        }
     }
 
     void restoresActiveTextAndCaretThroughQmlLifecycle() {

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -127,6 +127,18 @@ private slots:
         QCOMPARE(backend.activeSelectionEnd(), 4);
     }
 
+    void preservesActiveBufferStateAfterApplicationClosePreparation() {
+        Backend backend;
+
+        backend.updateActiveEditorState(4, 1, 4);
+        backend.prepareForApplicationClose();
+        backend.updateActiveEditorState(0, 0, 0);
+
+        QCOMPARE(backend.activeCursorPosition(), 4);
+        QCOMPARE(backend.activeSelectionStart(), 1);
+        QCOMPARE(backend.activeSelectionEnd(), 4);
+    }
+
     void findsInlineMarkdownRanges() {
         const auto markup = MarkdownHighlighter::inlineMarkup(
             QStringLiteral("**bold** and *italic* and [site](https://example.com)"));

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -6,6 +6,7 @@
 #include <QQuickStyle>
 
 #include "backend.h"
+#include "buffersession.h"
 #include "markdownhighlighter.h"
 
 class OmawriteTest : public QObject {
@@ -42,6 +43,66 @@ private slots:
         QCOMPARE(Backend::suggestedFileName(QString()), QStringLiteral("Untitled.md"));
         QCOMPARE(Backend::suggestedFileName(QStringLiteral("Already.md")),
                  QStringLiteral("Already.md"));
+    }
+
+    void restoresOrderedBuffersAndActiveCaret() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+
+        BufferSession session(stateDirectory.path());
+        const QString first = session.createBuffer();
+        session.updateBuffer(first, QString(), QStringLiteral("first"), 2, 1, 2, true);
+        const QString second = session.createBuffer();
+        session.updateBuffer(second, QString(), QStringLiteral("second"), 4, 4, 4, true);
+        session.selectBuffer(first);
+        QVERIFY(session.saveNow());
+
+        BufferSession restored(stateDirectory.path());
+        QVERIFY(restored.restore());
+        QCOMPARE(restored.activeBufferId(), first);
+        QCOMPARE(restored.buffers().size(), 2);
+        QCOMPARE(restored.buffers().at(0).toMap().value(QStringLiteral("text")),
+                 QStringLiteral("first"));
+        QCOMPARE(restored.buffers().at(0).toMap().value(QStringLiteral("cursorPosition")), 2);
+        QCOMPARE(restored.buffers().at(0).toMap().value(QStringLiteral("selectionStart")), 1);
+        QCOMPARE(restored.buffers().at(0).toMap().value(QStringLiteral("selectionEnd")), 2);
+        QCOMPARE(restored.buffers().at(1).toMap().value(QStringLiteral("text")),
+                 QStringLiteral("second"));
+    }
+
+    void activatesExistingBufferForSameFile() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+
+        BufferSession session(stateDirectory.path());
+        const QUrl fileUrl = QUrl::fromLocalFile(QStringLiteral("/tmp/note.md"));
+        const QString first = session.openBuffer(fileUrl, QStringLiteral("first"));
+        const QString second = session.openBuffer(fileUrl, QStringLiteral("second"));
+
+        QCOMPARE(second, first);
+        QCOMPARE(session.buffers().size(), 1);
+        QCOMPARE(session.buffers().constFirst().toMap().value(QStringLiteral("text")),
+                 QStringLiteral("first"));
+    }
+
+    void sessionSnapshotsDoNotModifyUserFiles() {
+        QTemporaryDir directory;
+        QVERIFY(directory.isValid());
+
+        const QString path = directory.filePath(QStringLiteral("note.md"));
+        QFile file(path);
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        QCOMPARE(file.write("original"), qint64(8));
+        file.close();
+
+        BufferSession session(directory.filePath(QStringLiteral("state")));
+        const QString id = session.openBuffer(QUrl::fromLocalFile(path), QStringLiteral("edited"));
+        session.updateBuffer(id, QUrl::fromLocalFile(path).toString(), QStringLiteral("edited"),
+                             6, 6, 6, true);
+        QVERIFY(session.saveNow());
+
+        QVERIFY(file.open(QIODevice::ReadOnly));
+        QCOMPARE(file.readAll(), QByteArray("original"));
     }
 
     void findsInlineMarkdownRanges() {

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -195,6 +195,31 @@ private slots:
         QVERIFY(!tabBar->property("visible").toBool());
     }
 
+    void cyclesTabsFromWindowShortcuts() {
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        Backend backend;
+        const QString first = backend.activeBufferId();
+        const QString second = backend.newBuffer();
+        const QString third = backend.newBuffer();
+
+        QQmlEngine engine;
+        engine.rootContext()->setContextProperty(QStringLiteral("backend"), &backend);
+        QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> window(component.create());
+        QVERIFY2(window, qPrintable(component.errorString()));
+
+        QVERIFY(QMetaObject::invokeMethod(window.get(), "selectAdjacentTab", Q_ARG(QVariant, 1)));
+        QCOMPARE(backend.activeBufferId(), first);
+        QVERIFY(QMetaObject::invokeMethod(window.get(), "selectAdjacentTab", Q_ARG(QVariant, -1)));
+        QCOMPARE(backend.activeBufferId(), third);
+        QVERIFY(backend.selectBuffer(second));
+        QVERIFY(QMetaObject::invokeMethod(window.get(), "selectAdjacentTab", Q_ARG(QVariant, 1)));
+        QCOMPARE(backend.activeBufferId(), third);
+    }
+
     void restoresActiveTextAndCaretThroughQmlLifecycle() {
         const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
         QVERIFY(!mainQmlPath.isEmpty());

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -518,6 +518,32 @@ private slots:
         QCOMPARE(backend.activeBufferId(), third);
     }
 
+    void cyclesToHiddenTabsAndScrollsThemIntoView() {
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        Backend backend;
+        for (int index = 0; index < 12; ++index)
+            backend.newBuffer();
+
+        QQmlEngine engine;
+        engine.rootContext()->setContextProperty(QStringLiteral("backend"), &backend);
+        QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> window(component.create());
+        QVERIFY2(window, qPrintable(component.errorString()));
+        window->setProperty("width", 280);
+
+        QObject *tabFlick = window->findChild<QObject *>(QStringLiteral("tabFlick"));
+        QVERIFY(tabFlick);
+        QTRY_VERIFY(tabFlick->property("contentWidth").toReal()
+                     > tabFlick->property("width").toReal());
+        QCOMPARE(tabFlick->property("contentX").toReal(), 0.0);
+
+        QVERIFY(QMetaObject::invokeMethod(window.get(), "selectAdjacentTab", Q_ARG(QVariant, -1)));
+        QTRY_VERIFY(tabFlick->property("contentX").toReal() > 0);
+    }
+
     void scopesDocumentShortcutsToTheirWindow() {
         const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
         QVERIFY(!mainQmlPath.isEmpty());

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -9,6 +9,7 @@
 #include "buffersession.h"
 #include "markdownhighlighter.h"
 #include "workspacesession.h"
+#include "windowmanager.h"
 
 class OmawriteTest : public QObject {
     Q_OBJECT
@@ -205,6 +206,26 @@ private slots:
         QCOMPARE(backend.buffers().size(), 1);
         QCOMPARE(backend.activeBufferId(), firstTab);
         QCOMPARE(backend.activeBufferText(), QStringLiteral("first"));
+    }
+
+    void windowManagerCreatesIndependentWritingWindows() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        WorkspaceSession session(stateDirectory.path());
+        QQmlEngine engine;
+        WindowManager manager(&session, &engine, QUrl::fromLocalFile(mainQmlPath));
+
+        Backend *first = manager.createWindow();
+        Backend *second = manager.createWindow();
+
+        QVERIFY(first);
+        QVERIFY(second);
+        QVERIFY(first != second);
+        QCOMPARE(manager.windowCount(), 2);
+        QCOMPARE(session.windows().size(), 2);
     }
 
     void preservesBufferTextWhenUpdatingCaret() {

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -70,6 +70,25 @@ private slots:
                  QStringLiteral("second"));
     }
 
+    void preservesBufferTextWhenUpdatingCaret() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+
+        BufferSession session(stateDirectory.path());
+        const QString id = session.createBuffer();
+        QVERIFY(session.updateBuffer(id, QString(), QStringLiteral("first"), 0, 0, 0, true));
+        QVERIFY(session.updateBufferCursor(id, 3, 1, 3));
+        QVERIFY(session.saveNow());
+
+        BufferSession restored(stateDirectory.path());
+        QVERIFY(restored.restore());
+        const QVariantMap buffer = restored.buffers().constFirst().toMap();
+        QCOMPARE(buffer.value(QStringLiteral("text")), QStringLiteral("first"));
+        QCOMPARE(buffer.value(QStringLiteral("cursorPosition")), 3);
+        QCOMPARE(buffer.value(QStringLiteral("selectionStart")), 1);
+        QCOMPARE(buffer.value(QStringLiteral("selectionEnd")), 3);
+    }
+
     void activatesExistingBufferForSameFile() {
         QTemporaryDir stateDirectory;
         QVERIFY(stateDirectory.isValid());
@@ -117,26 +136,55 @@ private slots:
         QCOMPARE(backend.activeBufferId(), first);
     }
 
-    void exposesActiveBufferCaretState() {
-        Backend backend;
+    void restoresActiveTextAndCaretThroughQmlLifecycle() {
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
 
-        backend.updateActiveEditorState(4, 1, 4);
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
 
-        QCOMPARE(backend.activeCursorPosition(), 4);
-        QCOMPARE(backend.activeSelectionStart(), 1);
-        QCOMPARE(backend.activeSelectionEnd(), 4);
-    }
+        {
+            Backend writer(stateDirectory.path());
+            QQmlEngine engine;
+            engine.rootContext()->setContextProperty(QStringLiteral("backend"), &writer);
+            QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+            QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+            QScopedPointer<QObject> window(component.create());
+            QVERIFY2(window, qPrintable(component.errorString()));
 
-    void preservesActiveBufferStateAfterApplicationClosePreparation() {
-        Backend backend;
+            QObject *editor = window->findChild<QObject *>(QStringLiteral("sourceEditor"));
+            QVERIFY(editor);
+            QTest::qWait(120);
+            QTRY_VERIFY(!writer.buffers().isEmpty());
+            editor->setProperty("text", QStringLiteral("First tab"));
+            editor->setProperty("cursorPosition", 5);
+            QTRY_COMPARE(writer.buffers().constFirst().toMap().value(QStringLiteral("text")),
+                         QStringLiteral("First tab"));
+            QTRY_COMPARE(writer.buffers().constFirst().toMap()
+                             .value(QStringLiteral("cursorPosition")).toInt(),
+                         5);
+            writer.prepareForApplicationClose();
+        }
 
-        backend.updateActiveEditorState(4, 1, 4);
-        backend.prepareForApplicationClose();
-        backend.updateActiveEditorState(0, 0, 0);
+        BufferSession persisted(stateDirectory.path());
+        QVERIFY(persisted.restore());
+        QCOMPARE(persisted.buffers().constFirst().toMap()
+                     .value(QStringLiteral("cursorPosition")).toInt(),
+                 5);
 
-        QCOMPARE(backend.activeCursorPosition(), 4);
-        QCOMPARE(backend.activeSelectionStart(), 1);
-        QCOMPARE(backend.activeSelectionEnd(), 4);
+        Backend reader(stateDirectory.path());
+        QQmlEngine engine;
+        engine.rootContext()->setContextProperty(QStringLiteral("backend"), &reader);
+        QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> window(component.create());
+        QVERIFY2(window, qPrintable(component.errorString()));
+
+        QObject *editor = window->findChild<QObject *>(QStringLiteral("sourceEditor"));
+        QVERIFY(editor);
+        QTRY_COMPARE(editor->property("text").toString(), QStringLiteral("First tab"));
+        QTRY_COMPARE(reader.activeCursorPosition(), 5);
+        QTRY_COMPARE(editor->property("cursorPosition").toInt(), 5);
     }
 
     void findsInlineMarkdownRanges() {

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -8,6 +8,7 @@
 #include "backend.h"
 #include "buffersession.h"
 #include "markdownhighlighter.h"
+#include "workspacesession.h"
 
 class OmawriteTest : public QObject {
     Q_OBJECT
@@ -68,6 +69,110 @@ private slots:
         QCOMPARE(restored.buffers().at(0).toMap().value(QStringLiteral("selectionEnd")), 2);
         QCOMPARE(restored.buffers().at(1).toMap().value(QStringLiteral("text")),
                  QStringLiteral("second"));
+    }
+
+    void restoresWorkspaceWindowsAndActiveCarets() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+
+        WorkspaceSession session(stateDirectory.path());
+        const QString firstWindow = session.createWindow(10, 20, 900, 700, false);
+        const QString firstTab = session.createTab(firstWindow, QUrl(), QStringLiteral("first"),
+                                                   2, 1, 2, true);
+        const QString secondTab = session.createTab(firstWindow, QUrl(), QStringLiteral("second"),
+                                                    4, 4, 4, true);
+        QVERIFY(session.setActiveTab(firstWindow, firstTab));
+
+        const QString secondWindow = session.createWindow(30, 40, 800, 600, true);
+        const QString thirdTab = session.createTab(secondWindow, QUrl(), QStringLiteral("third"),
+                                                   3, 0, 3, false);
+        QVERIFY(session.setActiveTab(secondWindow, thirdTab));
+        QVERIFY(session.saveNow());
+
+        WorkspaceSession restored(stateDirectory.path());
+        QVERIFY(restored.restore());
+        const QVariantList windows = restored.windows();
+        QCOMPARE(windows.size(), 2);
+
+        const QVariantMap first = windows.at(0).toMap();
+        QCOMPARE(first.value(QStringLiteral("x")).toInt(), 10);
+        QCOMPARE(first.value(QStringLiteral("activeTabId")).toString(), firstTab);
+        const QVariantList firstTabs = first.value(QStringLiteral("tabs")).toList();
+        QCOMPARE(firstTabs.size(), 2);
+        QCOMPARE(firstTabs.at(0).toMap().value(QStringLiteral("text")).toString(),
+                 QStringLiteral("first"));
+        QCOMPARE(firstTabs.at(0).toMap().value(QStringLiteral("cursorPosition")).toInt(), 2);
+        QCOMPARE(firstTabs.at(1).toMap().value(QStringLiteral("id")).toString(), secondTab);
+
+        const QVariantMap second = windows.at(1).toMap();
+        QCOMPARE(second.value(QStringLiteral("maximized")).toBool(), true);
+        QCOMPARE(second.value(QStringLiteral("activeTabId")).toString(), thirdTab);
+    }
+
+    void keepsLocalFilesUniqueAndMovesTheActiveTab() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+
+        WorkspaceSession session(stateDirectory.path());
+        const QString firstWindow = session.createWindow(0, 0, 900, 700, false);
+        const QString firstTab = session.createTab(firstWindow,
+                                                   QUrl::fromLocalFile(QStringLiteral("/tmp/one.md")),
+                                                   QStringLiteral("one"), 0, 0, 0, false);
+        const QString secondTab = session.createTab(firstWindow, QUrl(), QStringLiteral("two"),
+                                                    0, 0, 0, false);
+        const QString secondWindow = session.createWindow(0, 0, 800, 600, false);
+
+        QCOMPARE(session.findOpenLocalFile(QUrl::fromLocalFile(QStringLiteral("/tmp/one.md"))),
+                 firstTab);
+        QVERIFY(session.createTab(secondWindow,
+                                  QUrl::fromLocalFile(QStringLiteral("/tmp/one.md")),
+                                  QStringLiteral("other copy"), 0, 0, 0, false).isEmpty());
+
+        QVERIFY(session.moveActiveTab(firstWindow, -1));
+        const QVariantList tabs = session.windows().constFirst().toMap()
+            .value(QStringLiteral("tabs")).toList();
+        QCOMPARE(tabs.at(0).toMap().value(QStringLiteral("id")).toString(), secondTab);
+        QCOMPARE(session.windows().constFirst().toMap()
+                     .value(QStringLiteral("activeTabId")).toString(), secondTab);
+    }
+
+    void rejectsWorkspaceSnapshotsWithDuplicateLocalFiles() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+
+        const QJsonObject tab{{QStringLiteral("id"), QStringLiteral("first-tab")},
+                              {QStringLiteral("fileUrl"),
+                               QUrl::fromLocalFile(QStringLiteral("/tmp/note.md")).toString()},
+                              {QStringLiteral("text"), QStringLiteral("text")},
+                              {QStringLiteral("cursorPosition"), 0},
+                              {QStringLiteral("selectionStart"), 0},
+                              {QStringLiteral("selectionEnd"), 0},
+                              {QStringLiteral("modified"), false}};
+        const QJsonObject duplicateTab{{QStringLiteral("id"), QStringLiteral("second-tab")},
+                                       {QStringLiteral("fileUrl"),
+                                        QUrl::fromLocalFile(QStringLiteral("/tmp/note.md")).toString()},
+                                       {QStringLiteral("text"), QStringLiteral("text")},
+                                       {QStringLiteral("cursorPosition"), 0},
+                                       {QStringLiteral("selectionStart"), 0},
+                                       {QStringLiteral("selectionEnd"), 0},
+                                       {QStringLiteral("modified"), false}};
+        const QJsonObject window{{QStringLiteral("id"), QStringLiteral("window")},
+                                 {QStringLiteral("x"), 0},
+                                 {QStringLiteral("y"), 0},
+                                 {QStringLiteral("width"), 900},
+                                 {QStringLiteral("height"), 700},
+                                 {QStringLiteral("maximized"), false},
+                                 {QStringLiteral("activeTabId"), QStringLiteral("first-tab")},
+                                 {QStringLiteral("tabs"), QJsonArray{tab, duplicateTab}}};
+        QFile file(stateDirectory.filePath(QStringLiteral("session.json")));
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        file.write(QJsonDocument(QJsonObject{{QStringLiteral("version"), 1},
+                                              {QStringLiteral("windows"), QJsonArray{window}}})
+                       .toJson(QJsonDocument::Compact));
+        file.close();
+
+        WorkspaceSession session(stateDirectory.path());
+        QVERIFY(!session.restore());
     }
 
     void preservesBufferTextWhenUpdatingCaret() {

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -345,6 +345,29 @@ private slots:
         QCOMPARE(manager.windowCount(), 2);
     }
 
+    void windowManagerRecoversLegacySnapshotsAsUnsavedTabs() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+        const QString recoveryPath = stateDirectory.filePath(QStringLiteral("recovery-0.json"));
+        QFile recovery(recoveryPath);
+        QVERIFY(recovery.open(QIODevice::WriteOnly));
+        recovery.write(QJsonDocument(QJsonObject{{QStringLiteral("fileUrl"), QString()},
+                                                  {QStringLiteral("text"), QStringLiteral("draft")}})
+                           .toJson(QJsonDocument::Compact));
+        recovery.close();
+
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+        WorkspaceSession session(stateDirectory.path());
+        QQmlEngine engine;
+        WindowManager manager(&session, &engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY(manager.createWindow());
+
+        QCOMPARE(manager.recoverLegacySnapshots(), 1);
+        QCOMPARE(session.windows().constFirst().toMap().value(QStringLiteral("tabs")).toList().size(), 2);
+        QVERIFY(!QFile::exists(recoveryPath));
+    }
+
     void preservesBufferTextWhenUpdatingCaret() {
         QTemporaryDir stateDirectory;
         QVERIFY(stateDirectory.isValid());

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -136,6 +136,24 @@ private slots:
         QCOMPARE(backend.activeBufferId(), first);
     }
 
+    void derivesBufferTitles() {
+        Backend backend;
+
+        QCOMPARE(backend.bufferTitle({{QStringLiteral("fileUrl"), QString()},
+                                     {QStringLiteral("text"), QString()}}, 0),
+                 QStringLiteral("Untitled 1"));
+        QCOMPARE(backend.bufferTitle({{QStringLiteral("fileUrl"), QString()},
+                                     {QStringLiteral("text"), QStringLiteral("  Draft title\nBody")}}, 1),
+                 QStringLiteral("Draft title"));
+        QCOMPARE(backend.bufferTitle({{QStringLiteral("fileUrl"), QString()},
+                                     {QStringLiteral("text"), QString(40, QChar('a'))}}, 2),
+                 QStringLiteral("aaaaaaaaaaaaaaaaaaaaaaaaaaaa…"));
+        QCOMPARE(backend.bufferTitle({{QStringLiteral("fileUrl"),
+                                      QStringLiteral("file:///tmp/notes.md")},
+                                     {QStringLiteral("text"), QStringLiteral("Ignored")}}, 3),
+                 QStringLiteral("notes.md"));
+    }
+
     void restoresActiveTextAndCaretThroughQmlLifecycle() {
         const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
         QVERIFY(!mainQmlPath.isEmpty());

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -128,6 +128,10 @@ private slots:
         QVERIFY(session.createTab(secondWindow,
                                   QUrl::fromLocalFile(QStringLiteral("/tmp/one.md")),
                                   QStringLiteral("other copy"), 0, 0, 0, false).isEmpty());
+        QVERIFY(!session.updateTab(secondWindow, secondTab,
+                                   QUrl::fromLocalFile(QStringLiteral("/tmp/one.md")),
+                                   QStringLiteral("other copy"), 0, 0, 0, false));
+        QCOMPARE(session.windowIdForTab(firstTab), firstWindow);
 
         QVERIFY(session.moveActiveTab(firstWindow, -1));
         const QVariantList tabs = session.windows().constFirst().toMap()
@@ -191,6 +195,23 @@ private slots:
         QVERIFY(restoredWindow.value(QStringLiteral("activeTabId")).toString().isEmpty());
     }
 
+    void savesWorkspaceWindowGeometry() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+
+        WorkspaceSession session(stateDirectory.path());
+        const QString windowId = session.createWindow(10, 20, 900, 700, false);
+        session.createTab(windowId, QUrl(), QString(), 0, 0, 0, false);
+
+        QVERIFY(session.updateWindowGeometry(windowId, 30, 40, 1200, 800, true));
+        const QVariantMap window = session.window(windowId);
+        QCOMPARE(window.value(QStringLiteral("x")).toInt(), 30);
+        QCOMPARE(window.value(QStringLiteral("y")).toInt(), 40);
+        QCOMPARE(window.value(QStringLiteral("width")).toInt(), 1200);
+        QCOMPARE(window.value(QStringLiteral("height")).toInt(), 800);
+        QVERIFY(window.value(QStringLiteral("maximized")).toBool());
+    }
+
     void backendReadsTabsFromItsWorkspaceWindow() {
         QTemporaryDir stateDirectory;
         QVERIFY(stateDirectory.isValid());
@@ -226,6 +247,25 @@ private slots:
         QVERIFY(first != second);
         QCOMPARE(manager.windowCount(), 2);
         QCOMPARE(session.windows().size(), 2);
+    }
+
+    void windowManagerRestoresWritingWindows() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        WorkspaceSession session(stateDirectory.path());
+        const QString firstWindow = session.createWindow(10, 20, 900, 700, false);
+        session.createTab(firstWindow, QUrl(), QStringLiteral("first"), 0, 0, 0, true);
+        const QString secondWindow = session.createWindow(30, 40, 1200, 800, true);
+        session.createTab(secondWindow, QUrl(), QStringLiteral("second"), 0, 0, 0, true);
+
+        QQmlEngine engine;
+        WindowManager manager(&session, &engine, QUrl::fromLocalFile(mainQmlPath));
+
+        QCOMPARE(manager.restoreWindows(), 2);
+        QCOMPARE(manager.windowCount(), 2);
     }
 
     void preservesBufferTextWhenUpdatingCaret() {

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -117,6 +117,16 @@ private slots:
         QCOMPARE(backend.activeBufferId(), first);
     }
 
+    void exposesActiveBufferCaretState() {
+        Backend backend;
+
+        backend.updateActiveEditorState(4, 1, 4);
+
+        QCOMPARE(backend.activeCursorPosition(), 4);
+        QCOMPARE(backend.activeSelectionStart(), 1);
+        QCOMPARE(backend.activeSelectionEnd(), 4);
+    }
+
     void findsInlineMarkdownRanges() {
         const auto markup = MarkdownHighlighter::inlineMarkup(
             QStringLiteral("**bold** and *italic* and [site](https://example.com)"));

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -175,6 +175,21 @@ private slots:
         QVERIFY(!session.restore());
     }
 
+    void removesTheLastTabWithoutCreatingAReplacement() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+
+        WorkspaceSession session(stateDirectory.path());
+        const QString window = session.createWindow(0, 0, 900, 700, false);
+        const QString tab = session.createTab(window, QUrl(), QStringLiteral("draft"),
+                                              0, 0, 0, true);
+
+        QVERIFY(session.removeTab(window, tab));
+        const QVariantMap restoredWindow = session.windows().constFirst().toMap();
+        QVERIFY(restoredWindow.value(QStringLiteral("tabs")).toList().isEmpty());
+        QVERIFY(restoredWindow.value(QStringLiteral("activeTabId")).toString().isEmpty());
+    }
+
     void preservesBufferTextWhenUpdatingCaret() {
         QTemporaryDir stateDirectory;
         QVERIFY(stateDirectory.isValid());

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -152,7 +152,8 @@ private slots:
                               {QStringLiteral("cursorPosition"), 0},
                               {QStringLiteral("selectionStart"), 0},
                               {QStringLiteral("selectionEnd"), 0},
-                              {QStringLiteral("modified"), false}};
+                              {QStringLiteral("modified"), false},
+                              {QStringLiteral("externalChanged"), false}};
         const QJsonObject duplicateTab{{QStringLiteral("id"), QStringLiteral("second-tab")},
                                        {QStringLiteral("fileUrl"),
                                         QUrl::fromLocalFile(QStringLiteral("/tmp/note.md")).toString()},
@@ -160,7 +161,8 @@ private slots:
                                        {QStringLiteral("cursorPosition"), 0},
                                        {QStringLiteral("selectionStart"), 0},
                                        {QStringLiteral("selectionEnd"), 0},
-                                       {QStringLiteral("modified"), false}};
+                                       {QStringLiteral("modified"), false},
+                                       {QStringLiteral("externalChanged"), false}};
         const QJsonObject window{{QStringLiteral("id"), QStringLiteral("window")},
                                  {QStringLiteral("x"), 0},
                                  {QStringLiteral("y"), 0},
@@ -171,7 +173,7 @@ private slots:
                                  {QStringLiteral("tabs"), QJsonArray{tab, duplicateTab}}};
         QFile file(stateDirectory.filePath(QStringLiteral("session.json")));
         QVERIFY(file.open(QIODevice::WriteOnly));
-        file.write(QJsonDocument(QJsonObject{{QStringLiteral("version"), 1},
+        file.write(QJsonDocument(QJsonObject{{QStringLiteral("version"), 2},
                                               {QStringLiteral("windows"), QJsonArray{window}}})
                        .toJson(QJsonDocument::Compact));
         file.close();
@@ -290,6 +292,38 @@ private slots:
         QVERIFY(!session.findOpenLocalFile(QUrl::fromLocalFile(filePath)).isEmpty());
         QCOMPARE(session.windows().at(0).toMap().value(QStringLiteral("tabs")).toList().size(), 2);
         QCOMPARE(session.windows().at(1).toMap().value(QStringLiteral("tabs")).toList().size(), 1);
+    }
+
+    void windowManagerMarksBackgroundExternalChangesWithoutPrompting() {
+        QTemporaryDir stateDirectory;
+        QVERIFY(stateDirectory.isValid());
+        const QString filePath = stateDirectory.filePath(QStringLiteral("note.md"));
+        QFile file(filePath);
+        QVERIFY(file.open(QIODevice::WriteOnly | QIODevice::Text));
+        file.write("first");
+        file.close();
+
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        WorkspaceSession session(stateDirectory.path());
+        QQmlEngine engine;
+        WindowManager manager(&session, &engine, QUrl::fromLocalFile(mainQmlPath));
+        Backend *backend = manager.createWindow();
+        QVERIFY(backend);
+        backend->open(QUrl::fromLocalFile(filePath));
+        const QString fileTab = backend->activeBufferId();
+        backend->newBuffer();
+        QSignalSpy externalChangeSpy(backend, &Backend::externalChangeDetected);
+
+        QVERIFY(file.open(QIODevice::WriteOnly | QIODevice::Text));
+        file.write("second");
+        file.close();
+
+        QTRY_VERIFY(session.tab(fileTab).value(QStringLiteral("externalChanged")).toBool());
+        QCOMPARE(externalChangeSpy.count(), 0);
+        QVERIFY(backend->selectBuffer(fileTab));
+        QTRY_COMPARE(externalChangeSpy.count(), 1);
     }
 
     void windowManagerRestoresWritingWindows() {

--- a/tests/tst_omawrite.cpp
+++ b/tests/tst_omawrite.cpp
@@ -154,6 +154,47 @@ private slots:
                  QStringLiteral("notes.md"));
     }
 
+    void scrollsOverflowingTabs() {
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        Backend backend;
+        for (int index = 0; index < 12; ++index)
+            backend.newBuffer();
+
+        QQmlEngine engine;
+        engine.rootContext()->setContextProperty(QStringLiteral("backend"), &backend);
+        QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> window(component.create());
+        QVERIFY2(window, qPrintable(component.errorString()));
+        window->setProperty("width", 280);
+
+        QObject *tabFlick = window->findChild<QObject *>(QStringLiteral("tabFlick"));
+        QVERIFY(tabFlick);
+        QTRY_VERIFY(tabFlick->property("contentWidth").toReal()
+                     > tabFlick->property("width").toReal());
+        QVERIFY(QMetaObject::invokeMethod(window.get(), "scrollTabs", Q_ARG(QVariant, 1)));
+        QTRY_VERIFY(tabFlick->property("contentX").toReal() > 0);
+    }
+
+    void hidesTabBarForSingleBuffer() {
+        const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
+        QVERIFY(!mainQmlPath.isEmpty());
+
+        Backend backend;
+        QQmlEngine engine;
+        engine.rootContext()->setContextProperty(QStringLiteral("backend"), &backend);
+        QQmlComponent component(&engine, QUrl::fromLocalFile(mainQmlPath));
+        QVERIFY2(component.isReady(), qPrintable(component.errorString()));
+        QScopedPointer<QObject> window(component.create());
+        QVERIFY2(window, qPrintable(component.errorString()));
+
+        QObject *tabBar = window->findChild<QObject *>(QStringLiteral("tabBar"));
+        QVERIFY(tabBar);
+        QVERIFY(!tabBar->property("visible").toBool());
+    }
+
     void restoresActiveTextAndCaretThroughQmlLifecycle() {
         const QString mainQmlPath = QFINDTESTDATA("../src/Main.qml");
         QVERIFY(!mainQmlPath.isEmpty());


### PR DESCRIPTION
## The problem

Writing rarely starts and ends in one file, one sitting, or one window. Omawrite currently makes every document begin from scratch after a restart.

## The change

This gives Omawrite a small, durable writing workspace:

- Ctrl+T opens a new tab.
- Ctrl+W closes the current tab. Closing the last tab closes its window.
- Ctrl+N opens another Omawrite window in the same process.
- Ctrl+Tab and Ctrl+Shift+Tab move between tabs.
- Ctrl+Shift+PageUp and Ctrl+Shift+PageDown reorder tabs.
- Windows, tabs, text, active tab, cursor, selection, and geometry return after restart.
- A file can be open once across the whole workspace. Opening it again activates the existing tab.
- External changes mark background tabs without stealing focus; the choice to reload or keep the buffer appears only when that tab becomes active.

## One rule

The workspace is persisted separately from the files being edited. Automatic persistence writes only Omawrite-owned session state. A user file changes only after an explicit Save or Save As.

That is the whole point: restart-proof drafts without surprise writes.

## Recovery stays recovery

The existing recovery-*.json crash snapshots remain a separate path. On startup, each snapshot becomes an unsaved recovered tab and is consumed only after it has entered the durable workspace. No recovery data is written back to its original user file.

## Deliberate limits

- No tab drag and drop.
- No moving tabs between existing windows.
- No auto-save to named documents.

Those can be added later if they earn their complexity.

## Verification

- 35 Qt tests pass.
- Application build succeeds.
- Coverage includes session restoration, caret and selection restoration, multi-window creation, global file de-duplication, keyboard-scoped tab commands, background external changes, last-tab window closure, and legacy recovery import.

## Relationship to #59

This work started independently before #59 was published. After seeing that PR, I considered folding this into it or simply not opening a competing proposal.

I concluded that a separate review is useful. The two changes overlap on tabs and session restore, but take different paths: this PR never autosaves named user files and keeps crash recovery separate from normal workspace state.

#59 is a broader bundle of changes. This is intentionally a narrower slice with one product contract to review: Omawrite remembers the writing workspace, but it never writes for the writer without an explicit Save.
